### PR TITLE
Use f-string in error for unsupported `in_stream_type`

### DIFF
--- a/src/daq2lh5/build_raw.py
+++ b/src/daq2lh5/build_raw.py
@@ -182,7 +182,7 @@ def build_raw(
     elif in_stream_type == "MGDO":
         raise NotImplementedError("MGDO streaming not yet implemented")
     else:
-        raise NotImplementedError("unknown input stream type {in_stream_type}")
+        raise NotImplementedError(f"unknown input stream type {in_stream_type}")
 
     # initialize the stream and read header. Also initializes rb_lib
     if log.getEffectiveLevel() <= logging.INFO:


### PR DESCRIPTION
Very minor fix to use an f-string when an unsupported `in_stream_type` is specified for `build_raw`.