### PR TITLE
Fix extration of ids from rawid

### DIFF
--- a/src/daq2lh5/orca/orca_flashcam.py
+++ b/src/daq2lh5/orca/orca_flashcam.py
@@ -19,15 +19,15 @@ def get_key(fcid, board_id, fc_input: int) -> int:
 
 
 def get_fcid(key: int) -> int:
-    return int(np.floor(key / 1000000))
+    return int(key // 1000000)
 
 
 def get_board_id(key: int) -> int:
-    return int(np.floor(key / 100)) & 0xFFF
+    return int((key // 100) % 10000)
 
 
 def get_fc_input(key: int) -> int:
-    return int(key & 0xFF)
+    return int(key % 100)
 
 
 class ORFlashCamListenerConfigDecoder(OrcaDecoder):


### PR DESCRIPTION
`get_fcid` was working correctly, but proposed changes use similar coding style.

`get_board_id` and `get_fc_input`  did select a fixed length of bits instead of the decimals.

`get_board_id` is used only once in an error checking function which should never fire as long as the daq maps the FlashCam Address correctly in the output.