### PR TITLE
Bug fix: cast range to  when returning the key list in the FlashCam event decoder

### DIFF
--- a/src/daq2lh5/fc/fc_event_decoder.py
+++ b/src/daq2lh5/fc/fc_event_decoder.py
@@ -111,7 +111,7 @@ class FCEventDecoder(DataDecoder):
         self.decoded_values["tracelist"]["length_guess"] = self.fc_config["nadcs"].value
 
     def get_key_lists(self) -> range:
-        return [range(self.fc_config["nadcs"].value)]
+        return [list(range(self.fc_config["nadcs"].value))]
 
     def get_decoded_values(self, channel: int = None) -> dict[str, dict[str, Any]]:
         # FC uses the same values for all channels

--- a/tests/fc/test_fc_streamer.py
+++ b/tests/fc/test_fc_streamer.py
@@ -24,7 +24,7 @@ def test_default_rb_lib(lgnd_test_data):
     assert rb_lib["FCConfigDecoder"][0].out_name == "FCConfig"
     assert rb_lib["FCStatusDecoder"][0].out_name == "FCStatus"
     assert rb_lib["FCEventDecoder"][0].out_name == "FCEvent"
-    assert rb_lib["FCEventDecoder"][0].key_list == range(0, 6)
+    assert rb_lib["FCEventDecoder"][0].key_list == list(range(0, 6))
 
 
 def test_open_stream(lgnd_test_data):


### PR DESCRIPTION
should fix error reported by Carmen