### PR TITLE
Added decoder for llamaDAQ data

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -37,9 +37,9 @@ install_requires =
     legend-pydataobj>=1.6
     numpy>=1.21
     pyfcutils
+    pyyaml
     tqdm>=4.27
     xmltodict
-    pyyaml
 python_requires = >=3.9
 include_package_data = True
 package_dir =

--- a/src/daq2lh5/build_raw.py
+++ b/src/daq2lh5/build_raw.py
@@ -12,8 +12,8 @@ from tqdm.auto import tqdm
 
 from .compass.compass_streamer import CompassStreamer
 from .fc.fc_streamer import FCStreamer
-from .orca.orca_streamer import OrcaStreamer
 from .llama.llama_streamer import LLAMAStreamer
+from .orca.orca_streamer import OrcaStreamer
 from .raw_buffer import RawBufferLibrary, write_to_lh5_and_clear
 
 log = logging.getLogger(__name__)

--- a/src/daq2lh5/data_streamer.py
+++ b/src/daq2lh5/data_streamer.py
@@ -350,7 +350,7 @@ class DataStreamer(ABC):
                     if len(key_list) == 1:
                         this_name = f"{dec_key}_{key_list[0]}"
                     else:
-                        this_name = f"{dec_key}_{ii}"     #this can cause a name clash e.g. for [[1],[2,3]] ...
+                        this_name = f"{dec_key}_{ii}"  # this can cause a name clash e.g. for [[1],[2,3]] ...
                 rb = RawBuffer(
                     key_list=key_list, out_stream=out_stream, out_name=this_name
                 )

--- a/src/daq2lh5/llama/llama_base.py
+++ b/src/daq2lh5/llama/llama_base.py
@@ -1,14 +1,14 @@
 """
 General utilities for llamaDAQ data decoding
 """
+
 from __future__ import annotations
 
 import logging
-from typing import Dict, Any
 
 log = logging.getLogger(__name__)
 
-#build a unique flat identifier for fadc and channel together
+
+# build a unique flat identifier for fadc and channel together
 def join_fadcid_chid(fadcid: int, chid: int) -> int:
     return (fadcid << 4) + chid
-

--- a/src/daq2lh5/llama/llama_event_decoder.py
+++ b/src/daq2lh5/llama/llama_event_decoder.py
@@ -2,10 +2,10 @@ from __future__ import annotations
 
 import copy
 import logging
-from typing import Any, Dict
-import numpy as np
+from typing import Any
 
 import lgdo
+import numpy as np
 
 from ..data_decoder import DataDecoder
 from .llama_header_decoder import LLAMA_Channel_Configs_t
@@ -16,19 +16,19 @@ log = logging.getLogger(__name__)
 llama_decoded_values_template = {
     # packet index in file
     "packet_id": {"dtype": "uint32"},
-    #combined index of FADC and channel
+    # combined index of FADC and channel
     "fch_id": {"dtype": "uint32"},
     # time since epoch
-    "timestamp": {"dtype": "uint64", "units": "clock_ticks"}
+    "timestamp": {"dtype": "uint64", "units": "clock_ticks"},
     # waveform data --> not always present
-    #"waveform": {
+    # "waveform": {
     #    "dtype": "uint16",
     #    "datatype": "waveform",
     #    "wf_len": 65532,  # max value. override this before initializing buffers to save RAM
     #    "dt": 8,  # override if a different clock rate is used
     #    "dt_units": "ns",
     #    "t0_units": "ns",
-    #}
+    # }
 }
 """Default llamaDAQ SIS3316 Event decoded values.
 
@@ -37,11 +37,15 @@ Warning
 This configuration can be dynamically modified by the decoder at runtime.
 """
 
-def check_dict_spec_equal(d1: dict[str, Any], d2: dict[str, Any], specs: list[str]) -> bool:
+
+def check_dict_spec_equal(
+    d1: dict[str, Any], d2: dict[str, Any], specs: list[str]
+) -> bool:
     for spec in specs:
         if d1.get(spec) != d2.get(spec):
             return False
     return True
+
 
 class LLAMAEventDecoder(DataDecoder):
     """Decode llamaDAQ SIS3316 digitizer event data."""
@@ -53,9 +57,15 @@ class LLAMAEventDecoder(DataDecoder):
         super().__init__(*args, **kwargs)
         self.skipped_channels = {}
         self.channel_configs = None
-        self.dt_raw: dict[int, float] = {} # need to buffer that to update t0 for avg waveforms per event
-        self.t0_raw: dict[int, float] = {} # store when receiving channel configs and use for each waveform
-        self.t0_avg_const: dict[int, float] = {} #constant part of the t0 of averaged waveforms
+        self.dt_raw: dict[int, float] = (
+            {}
+        )  # need to buffer that to update t0 for avg waveforms per event
+        self.t0_raw: dict[int, float] = (
+            {}
+        )  # store when receiving channel configs and use for each waveform
+        self.t0_avg_const: dict[int, float] = (
+            {}
+        )  # constant part of the t0 of averaged waveforms
 
     def set_channel_configs(self, channel_configs: LLAMA_Channel_Configs_t) -> None:
         """Receive channel configurations from llama_streamer after header was parsed
@@ -67,18 +77,27 @@ class LLAMAEventDecoder(DataDecoder):
             format_bits = config["format_bits"]
             sample_clock_freq = config["sample_freq"]
             avg_mode = config["avg_mode"]
-            dt_raw: float = 1/sample_clock_freq*1000
+            dt_raw: float = 1 / sample_clock_freq * 1000
             dt_avg: float = dt_raw * (1 << (avg_mode + 1))
             # t0 generation functions from llamaDAQ -> EventConfig.hh
-            t0_raw: float = (float(config["sample_start_index"]) - float(config["sample_pretrigger"])) * dt_raw  # location of the trigger is at t = 0
-            t0_avg: float = -float(config["sample_pretrigger"]) * float(dt_raw) - float(config["avg_sample_pretrigger"]) * dt_avg  # additional offset to be added independently for every event
+            t0_raw: float = (
+                float(config["sample_start_index"]) - float(config["sample_pretrigger"])
+            ) * dt_raw  # location of the trigger is at t = 0
+            t0_avg: float = (
+                -float(config["sample_pretrigger"]) * float(dt_raw)
+                - float(config["avg_sample_pretrigger"]) * dt_avg
+            )  # additional offset to be added independently for every event
             self.dt_raw[fch] = dt_raw
             self.t0_raw[fch] = t0_raw
             self.t0_avg_const[fch] = t0_avg
             if config["sample_length"] > 0:
-                self.__add_waveform(self.decoded_values[fch], False, config["sample_length"], dt_raw)
+                self.__add_waveform(
+                    self.decoded_values[fch], False, config["sample_length"], dt_raw
+                )
             if config["avg_sample_length"] > 0 and avg_mode > 0:
-                self.__add_waveform(self.decoded_values[fch], True, config["avg_sample_length"], dt_avg)
+                self.__add_waveform(
+                    self.decoded_values[fch], True, config["avg_sample_length"], dt_avg
+                )
             if format_bits & 0x01:
                 self.__add_accum1till6(self.decoded_values[fch])
             if format_bits & 0x02:
@@ -94,12 +113,14 @@ class LLAMAEventDecoder(DataDecoder):
         Each inner list are the fch_id's which share the exact same settings (trace lengths, avg mode, ...),
         so they can end up in the same buffer.
         """
-        if self.channel_configs is None: 
-            raise RuntimeError("Identification of key lists requires channel configs to be set!")
+        if self.channel_configs is None:
+            raise RuntimeError(
+                "Identification of key lists requires channel configs to be set!"
+            )
 
         params_for_equality = ["sample_length", "avg_sample_length", "avg_mode"]
         check_equal = lambda c1, c2: check_dict_spec_equal(c1, c2, params_for_equality)
-        kll: list[list[int]] = []      #key-list-list
+        kll: list[list[int]] = []  # key-list-list
         for fch_id, config in self.channel_configs.items():
             for kl in kll:
                 # use 1st entry of a list of list as "archetype"
@@ -108,11 +129,10 @@ class LLAMAEventDecoder(DataDecoder):
                     break
             else:
                 kll.append([fch_id])
-        log.debug("key lists are: {}".format(repr(kll)))
+        log.debug(f"key lists are: {repr(kll)}")
         return kll
-        
 
-    #copied from ORCA SIS3316
+    # copied from ORCA SIS3316
     def get_decoded_values(self, key: int = None) -> dict[str, Any]:
         if key is None:
             raise RuntimeError("Key is None!")
@@ -124,13 +144,15 @@ class LLAMAEventDecoder(DataDecoder):
         else:
             dec_vals_list = self.decoded_values[key]
             return dec_vals_list
-    
-    def decode_packet(self, packet: bytes, 
-            evt_rbkd: lgdo.Table | dict[int, lgdo.Table],
-            packet_id: int,
-            fch_id: int
-            #header: lgdo.Table | dict[int, lgdo.Table]
-            ) -> bool:
+
+    def decode_packet(
+        self,
+        packet: bytes,
+        evt_rbkd: lgdo.Table | dict[int, lgdo.Table],
+        packet_id: int,
+        fch_id: int,
+        # header: lgdo.Table | dict[int, lgdo.Table]
+    ) -> bool:
         """
         Decodes a single packet, which is a single SIS3316 event, as specified in the Struck manual.
         A single packet corresponds to a single event and channel, and has a unique timestamp.
@@ -145,7 +167,7 @@ class LLAMAEventDecoder(DataDecoder):
                 log.debug(f"evt_rbkd: {evt_rbkd.keys()}")
             self.skipped_channels[fch_id] += 1
             return False
-        
+
         tbl = evt_rbkd[fch_id].lgdo
         ii = evt_rbkd[fch_id].loc
 
@@ -154,9 +176,9 @@ class LLAMAEventDecoder(DataDecoder):
         evt_data_16 = np.frombuffer(packet, dtype=np.uint16)
 
         # e sti gran binaries non ce li metti
-        #fch_id = (evt_data_32[0] >> 4) & 0x00000fff  --> to be read earlier, since we need size for chopping out the event from the stream
-        timestamp = ((evt_data_32[0] & 0xffff0000) << 16) + evt_data_32[1]
-        format_bits = (evt_data_32[0]) & 0x0000000f
+        # fch_id = (evt_data_32[0] >> 4) & 0x00000fff  --> to be read earlier, since we need size for chopping out the event from the stream
+        timestamp = ((evt_data_32[0] & 0xFFFF0000) << 16) + evt_data_32[1]
+        format_bits = (evt_data_32[0]) & 0x0000000F
         tbl["fch_id"].nda[ii] = fch_id
         tbl["packet_id"].nda[ii] = packet_id
         tbl["timestamp"].nda[ii] = timestamp
@@ -164,48 +186,50 @@ class LLAMAEventDecoder(DataDecoder):
         if format_bits & 0x1:
             tbl["peakHighValue"].nda[ii] = evt_data_16[4]
             tbl["peakHighIndex"].nda[ii] = evt_data_16[5]
-            tbl["information"].nda[ii] = (evt_data_32[offset+1] >> 24) & 0xff
-            tbl["accSum1"].nda[ii] = evt_data_32[offset+2]
-            tbl["accSum2"].nda[ii] = evt_data_32[offset+3]
-            tbl["accSum3"].nda[ii] = evt_data_32[offset+4]
-            tbl["accSum4"].nda[ii] = evt_data_32[offset+5]
-            tbl["accSum5"].nda[ii] = evt_data_32[offset+6]
-            tbl["accSum6"].nda[ii] = evt_data_32[offset+7]
+            tbl["information"].nda[ii] = (evt_data_32[offset + 1] >> 24) & 0xFF
+            tbl["accSum1"].nda[ii] = evt_data_32[offset + 2]
+            tbl["accSum2"].nda[ii] = evt_data_32[offset + 3]
+            tbl["accSum3"].nda[ii] = evt_data_32[offset + 4]
+            tbl["accSum4"].nda[ii] = evt_data_32[offset + 5]
+            tbl["accSum5"].nda[ii] = evt_data_32[offset + 6]
+            tbl["accSum6"].nda[ii] = evt_data_32[offset + 7]
             offset += 7
         if format_bits & 0x2:
-            tbl["accSum7"].nda[ii] = evt_data_32[offset+0]
-            tbl["accSum8"].nda[ii] = evt_data_32[offset+1]
+            tbl["accSum7"].nda[ii] = evt_data_32[offset + 0]
+            tbl["accSum8"].nda[ii] = evt_data_32[offset + 1]
             offset += 2
         if format_bits & 0x4:
-            tbl["mawMax"].nda[ii] = evt_data_32[offset+0]
-            tbl["mawBefore"].nda[ii] = evt_data_32[offset+1]
-            tbl["mawAfter"].nda[ii] = evt_data_32[offset+2]
+            tbl["mawMax"].nda[ii] = evt_data_32[offset + 0]
+            tbl["mawBefore"].nda[ii] = evt_data_32[offset + 1]
+            tbl["mawAfter"].nda[ii] = evt_data_32[offset + 2]
             offset += 3
         if format_bits & 0x8:
-            tbl["startEnergy"].nda[ii] = evt_data_32[offset+0]
-            tbl["maxEnergy"].nda[ii] = evt_data_32[offset+1]
+            tbl["startEnergy"].nda[ii] = evt_data_32[offset + 0]
+            tbl["maxEnergy"].nda[ii] = evt_data_32[offset + 1]
             offset += 2
 
-        raw_length_32 = (evt_data_32[offset+0]) & 0x03ffffff
-        status_flag = ((evt_data_32[offset+0]) & 0x04000000) >> 26 #bit 26
-        maw_test_flag = ((evt_data_32[offset+0]) & 0x08000000) >> 27 #bit 27
+        raw_length_32 = (evt_data_32[offset + 0]) & 0x03FFFFFF
+        status_flag = ((evt_data_32[offset + 0]) & 0x04000000) >> 26  # bit 26
+        maw_test_flag = ((evt_data_32[offset + 0]) & 0x08000000) >> 27  # bit 27
         avg_data_coming = False
-        if evt_data_32[offset+0] & 0xf0000000 == 0xe0000000:
+        if evt_data_32[offset + 0] & 0xF0000000 == 0xE0000000:
             avg_data_coming = False
-        elif evt_data_32[offset+0] & 0xf0000000 == 0xa0000000:
+        elif evt_data_32[offset + 0] & 0xF0000000 == 0xA0000000:
             avg_data_coming = True
         else:
             raise RuntimeError("Data corruption 1!")
-        offset += 1 
+        offset += 1
         avg_length_32 = 0
         if avg_data_coming:
-            avg_count_status = (evt_data_32[offset+0] & 0x00ff0000) >> 16  # bits 23 - 16
-            avg_length_32 = evt_data_32[offset+0] & 0x0000ffff
-            if evt_data_32[offset+0] & 0xf0000000 != 0xe0000000:
+            avg_count_status = (
+                evt_data_32[offset + 0] & 0x00FF0000
+            ) >> 16  # bits 23 - 16
+            avg_length_32 = evt_data_32[offset + 0] & 0x0000FFFF
+            if evt_data_32[offset + 0] & 0xF0000000 != 0xE0000000:
                 raise RuntimeError("Data corruption 2!")
             offset += 1
-        
-        # --- now the offset points to the raw wf data --- 
+
+        # --- now the offset points to the raw wf data ---
 
         if maw_test_flag:
             raise RuntimeError("Cannot handle data with MAW test data!")
@@ -218,30 +242,44 @@ class LLAMAEventDecoder(DataDecoder):
 
         # error check: waveform size must match expectations
         if raw_length_16 + avg_length_16 != expected_wf_length:
-            raise RuntimeError("Waveform sizes {} (raw) and {} (avg) doesn't match expected size {}.".format(raw_length_16, avg_length_16, expected_wf_length))
-        
-        #store waveform if available:
+            raise RuntimeError(
+                f"Waveform sizes {raw_length_16} (raw) and {avg_length_16} (avg) doesn't match expected size {expected_wf_length}."
+            )
+
+        # store waveform if available:
         if raw_length_16 > 0:
-            tbl["waveform"]["values"].nda[ii] = evt_data_16[offset * 2 : offset * 2 + raw_length_16]
+            tbl["waveform"]["values"].nda[ii] = evt_data_16[
+                offset * 2 : offset * 2 + raw_length_16
+            ]
             offset += raw_length_32
             tbl["waveform"]["t0"].nda[ii] = self.t0_raw[fch_id]
-        
-        #store pre-averaged (avg) waveform if available:
+
+        # store pre-averaged (avg) waveform if available:
         if avg_length_16 > 0:
-            tbl["avgwaveform"]["values"].nda[ii] = evt_data_16[offset * 2 : offset * 2 + avg_length_16]
+            tbl["avgwaveform"]["values"].nda[ii] = evt_data_16[
+                offset * 2 : offset * 2 + avg_length_16
+            ]
             offset += avg_length_32
             # need to update avg waveform t0 based on the offset I get per event
-            tbl["avgwaveform"]["t0"].nda[ii] = self.t0_avg_const[fch_id] + float(avg_count_status) * self.dt_raw[fch_id]
+            tbl["avgwaveform"]["t0"].nda[ii] = (
+                self.t0_avg_const[fch_id]
+                + float(avg_count_status) * self.dt_raw[fch_id]
+            )
 
         if offset != len(evt_data_32):
-            raise RuntimeError("I messed up...")     
+            raise RuntimeError("I messed up...")
 
         evt_rbkd[fch_id].loc += 1
 
         return evt_rbkd[fch_id].is_full()
 
-
-    def __add_waveform(self, decoded_values_fch: dict[str, Any], is_avg: bool, max_samples: int, dt: float) -> None:
+    def __add_waveform(
+        self,
+        decoded_values_fch: dict[str, Any],
+        is_avg: bool,
+        max_samples: int,
+        dt: float,
+    ) -> None:
         """
         Averaged samples are available from the 125 MHz (16 bit) variatnt of the SIS3316 and can be stored independently of raw samples.
         I use waveform for raw samples (dt from clock itself) and avgwaveform from averaged samples (dt from clock * avg number).
@@ -253,8 +291,8 @@ class LLAMAEventDecoder(DataDecoder):
             "dtype": "uint16",
             "datatype": "waveform",
             "wf_len": max_samples,  # max value. override this before initializing buffers to save RAM
-            "dt": dt, # the sample pitch (inverse of clock speed)
-            #"t0": t0, # Adding t0 here does not work
+            "dt": dt,  # the sample pitch (inverse of clock speed)
+            # "t0": t0, # Adding t0 here does not work
             "dt_units": "ns",
             "t0_units": "ns",
         }
@@ -282,4 +320,3 @@ class LLAMAEventDecoder(DataDecoder):
     def __add_energy(self, decoded_values_fch: dict[str, Any]) -> None:
         decoded_values_fch["startEnergy"] = {"dtype": "uint32", "units": "adc"}
         decoded_values_fch["maxEnergy"] = {"dtype": "uint32", "units": "adc"}
-

--- a/src/daq2lh5/llama/llama_header_decoder.py
+++ b/src/daq2lh5/llama/llama_header_decoder.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 
-import logging
 import io
-import numpy as np
-from typing import Dict, Any
+import logging
+from typing import Any, Dict
 
 import lgdo
+import numpy as np
 
 from ..data_decoder import DataDecoder
 from .llama_base import join_fadcid_chid
@@ -14,6 +14,7 @@ log = logging.getLogger(__name__)
 
 LLAMA_Channel_Configs_t = Dict[int, Dict[str, Any]]
 
+
 class LLAMAHeaderDecoder(DataDecoder):  # DataDecoder currently unused
     """
     Decode llamaDAQ header data. Includes the file header as well as all available ("open") channel configurations.
@@ -21,44 +22,48 @@ class LLAMAHeaderDecoder(DataDecoder):  # DataDecoder currently unused
 
     @staticmethod
     def magic_bytes() -> int:
-        return 0x4972414c
+        return 0x4972414C
 
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
         self.config = lgdo.Struct()
         self.channel_configs = None
-        self.verbose = True ### debug
+        self.verbose = True  ### debug
 
     def decode_header(self, f_in: io.BufferedReader) -> lgdo.Struct:
         n_bytes_read = 0
 
-        f_in.seek(0)    #should be there anyhow, but re-set if not
-        header = f_in.read(16) #read 16 bytes
+        f_in.seek(0)  # should be there anyhow, but re-set if not
+        header = f_in.read(16)  # read 16 bytes
         n_bytes_read += 16
         evt_data_32 = np.fromstring(header, dtype=np.uint32)
         evt_data_16 = np.fromstring(header, dtype=np.uint16)
 
-        #line0: magic bytes
+        # line0: magic bytes
         magic = evt_data_32[0]
-        #print(hex(magic))
+        # print(hex(magic))
         if magic == self.magic_bytes():
             log.info("Read in file as llamaDAQ-SIS3316, magic bytes correct.")
         else:
             log.error("Magic bytes not matching for llamaDAQ file!")
             raise RuntimeError("wrong file type")
-    
+
         self.version_major = evt_data_16[4]
         self.version_minor = evt_data_16[3]
         self.version_patch = evt_data_16[2]
         self.length_econf = evt_data_16[5]
         self.number_chOpen = evt_data_32[3]
-        
-        log.debug("File version: {}.{}.{}".format(self.version_major, self.version_minor, self.version_patch))
-        log.debug("{} channels open, each config {} bytes long".format(self.number_chOpen, self.length_econf))
+
+        log.debug(
+            f"File version: {self.version_major}.{self.version_minor}.{self.version_patch}"
+        )
+        log.debug(
+            f"{self.number_chOpen} channels open, each config {self.length_econf} bytes long"
+        )
 
         n_bytes_read += self.__decode_channelConfigs(f_in)
 
-        #print(self.channel_configs[0]["MAW3_offset"])
+        # print(self.channel_configs[0]["MAW3_offset"])
 
         # assemble LGDO struct:
         self.config.add_field("version_major", lgdo.Scalar(self.version_major))
@@ -66,20 +71,19 @@ class LLAMAHeaderDecoder(DataDecoder):  # DataDecoder currently unused
         self.config.add_field("version_patch", lgdo.Scalar(self.version_patch))
         self.config.add_field("length_econf", lgdo.Scalar(self.length_econf))
         self.config.add_field("number_chOpen", lgdo.Scalar(self.number_chOpen))
-        
+
         for fch_id, fch_content in self.channel_configs.items():
             fch_lgdo = lgdo.Struct()
             for key, value in fch_content.items():
                 fch_lgdo.add_field(key, lgdo.Scalar(value))
-            self.config.add_field("fch_{:02d}".format(fch_id), fch_lgdo)
-
+            self.config.add_field(f"fch_{fch_id:02d}", fch_lgdo)
 
         return self.config, n_bytes_read
-    
-    #override from DataDecoder
+
+    # override from DataDecoder
     def make_lgdo(self, key: int = None, size: int = None) -> lgdo.Struct:
         return self.config
-    
+
     def get_channel_configs(self) -> LLAMA_Channel_Configs_t:
         return self.channel_configs
 
@@ -87,13 +91,13 @@ class LLAMAHeaderDecoder(DataDecoder):  # DataDecoder currently unused
         """
         Reads the metadata from the beginning of the file (the "channel configuration" part, directly after the file header).
         Creates a dictionary of the metadata for each FADC/channel combination, which is returned
-        
+
         FADC-ID and channel-ID are combined into a single id for flattening:
             (fadcid << 4) + chid
-                      
+
         returns number of bytes read
         """
-        #f_in.seek(16)    #should be after file header anyhow, but re-set if not
+        # f_in.seek(16)    #should be after file header anyhow, but re-set if not
         n_bytes_read = 0
         self.channel_configs = {}
 
@@ -102,28 +106,32 @@ class LLAMAHeaderDecoder(DataDecoder):  # DataDecoder currently unused
 
         for i in range(0, self.number_chOpen):
             if self.verbose > 1:
-                print("reading in channel config {}".format(i))
-                
+                print(f"reading in channel config {i}")
+
             channel = f_in.read(self.length_econf)
             n_bytes_read += self.length_econf
             ch_dpf = channel[16:32]
             evt_data_32 = np.frombuffer(channel, dtype=np.uint32)
             evt_data_dpf = np.frombuffer(ch_dpf, dtype=np.float64)
-            
+
             fadcIndex = evt_data_32[0]
             channelIndex = evt_data_32[1]
             fch_id = join_fadcid_chid(fadcIndex, channelIndex)
-            
+
             if fch_id in self.channel_configs:
-                raise RuntimeError("duplicate channel configuration in file: FADCID: {}, ChannelID: {}".format(fadcIndex, channelIndex))
+                raise RuntimeError(
+                    f"duplicate channel configuration in file: FADCID: {fadcIndex}, ChannelID: {channelIndex}"
+                )
             else:
                 self.channel_configs[fch_id] = {}
-                
+
             self.channel_configs[fch_id]["14BitFlag"] = evt_data_32[2] & 0x00000001
             if evt_data_32[2] & 0x00000002 == 0:
                 print("WARNING: Channel in configuration marked as non-open!")
             self.channel_configs[fch_id]["ADC_offset"] = evt_data_32[3]
-            self.channel_configs[fch_id]["sample_freq"] = evt_data_dpf[0]     #64 bit float
+            self.channel_configs[fch_id]["sample_freq"] = evt_data_dpf[
+                0
+            ]  # 64 bit float
             self.channel_configs[fch_id]["gain"] = evt_data_dpf[1]
             self.channel_configs[fch_id]["format_bits"] = evt_data_32[8]
             self.channel_configs[fch_id]["sample_start_index"] = evt_data_32[9]
@@ -141,6 +149,3 @@ class LLAMAHeaderDecoder(DataDecoder):  # DataDecoder currently unused
             self.channel_configs[fch_id]["energy_offset"] = evt_data_32[21]
 
         return n_bytes_read
-
-
-            

--- a/src/daq2lh5/logging.py
+++ b/src/daq2lh5/logging.py
@@ -11,7 +11,8 @@ ERROR = logging.ERROR
 FATAL = logging.FATAL
 CRITICAL = logging.CRITICAL
 
-root=logging.root
+root = logging.root
+
 
 def setup(level: int = logging.INFO, logger: logging.Logger = None) -> None:
     """Setup a colorful logging output.


### PR DESCRIPTION
Added a decoder for raw data created by llamaDAQ reading out a SIS3316 FADC.

Can decode header data (accumulators, etc), raw samples & averaged samples.
Averaged samples can come from the SIS3316-16 version (hardware averaging) or emulated by llamaDAQ.

Raw data has to be produced in the "improved" or "emulated" (v2.1.0+) formats of llamaDAQ.

Fixed missing pyyaml and broken debug logger on the way...