### PR TITLE
Added decoder for llamaDAQ

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -37,9 +37,9 @@ install_requires =
     legend-pydataobj>=1.6
     numpy>=1.21
     pyfcutils
+    pyyaml
     tqdm>=4.27
     xmltodict
-    pyyaml
 python_requires = >=3.9
 include_package_data = True
 package_dir =

--- a/setup.cfg
+++ b/setup.cfg
@@ -39,6 +39,7 @@ install_requires =
     pyfcutils
     tqdm>=4.27
     xmltodict
+    pyyaml
 python_requires = >=3.9
 include_package_data = True
 package_dir =

--- a/src/daq2lh5/build_raw.py
+++ b/src/daq2lh5/build_raw.py
@@ -13,6 +13,7 @@ from tqdm.auto import tqdm
 from .compass.compass_streamer import CompassStreamer
 from .fc.fc_streamer import FCStreamer
 from .orca.orca_streamer import OrcaStreamer
+from .llama.llama_streamer import LLAMAStreamer
 from .raw_buffer import RawBufferLibrary, write_to_lh5_and_clear
 
 log = logging.getLogger(__name__)
@@ -180,7 +181,7 @@ def build_raw(
     elif in_stream_type == "Compass":
         streamer = CompassStreamer(compass_config_file)
     elif in_stream_type == "LlamaDaq":
-        raise NotImplementedError("LlamaDaq streaming not yet implemented")
+        streamer = LLAMAStreamer()
     elif in_stream_type == "MGDO":
         raise NotImplementedError("MGDO streaming not yet implemented")
     else:

--- a/src/daq2lh5/build_raw.py
+++ b/src/daq2lh5/build_raw.py
@@ -12,8 +12,8 @@ from tqdm.auto import tqdm
 
 from .compass.compass_streamer import CompassStreamer
 from .fc.fc_streamer import FCStreamer
-from .orca.orca_streamer import OrcaStreamer
 from .llama.llama_streamer import LLAMAStreamer
+from .orca.orca_streamer import OrcaStreamer
 from .raw_buffer import RawBufferLibrary, write_to_lh5_and_clear
 
 log = logging.getLogger(__name__)

--- a/src/daq2lh5/data_streamer.py
+++ b/src/daq2lh5/data_streamer.py
@@ -350,7 +350,7 @@ class DataStreamer(ABC):
                     if len(key_list) == 1:
                         this_name = f"{dec_key}_{key_list[0]}"
                     else:
-                        this_name = f"{dec_key}_{ii}"
+                        this_name = f"{dec_key}_{ii}"     #this can cause a name clash e.g. for [[1],[2,3]] ...
                 rb = RawBuffer(
                     key_list=key_list, out_stream=out_stream, out_name=this_name
                 )

--- a/src/daq2lh5/data_streamer.py
+++ b/src/daq2lh5/data_streamer.py
@@ -350,7 +350,7 @@ class DataStreamer(ABC):
                     if len(key_list) == 1:
                         this_name = f"{dec_key}_{key_list[0]}"
                     else:
-                        this_name = f"{dec_key}_{ii}"     #this can cause a name clash e.g. for [[1],[2,3]] ...
+                        this_name = f"{dec_key}_{ii}"  # this can cause a name clash e.g. for [[1],[2,3]] ...
                 rb = RawBuffer(
                     key_list=key_list, out_stream=out_stream, out_name=this_name
                 )

--- a/src/daq2lh5/llama/llama_base.py
+++ b/src/daq2lh5/llama/llama_base.py
@@ -1,0 +1,14 @@
+"""
+General utilities for llamaDAQ data decoding
+"""
+from __future__ import annotations
+
+import logging
+from typing import Dict, Any
+
+log = logging.getLogger(__name__)
+
+#build a unique flat identifier for fadc and channel together
+def join_fadcid_chid(fadcid: int, chid: int) -> int:
+    return (fadcid << 4) + chid
+

--- a/src/daq2lh5/llama/llama_base.py
+++ b/src/daq2lh5/llama/llama_base.py
@@ -1,14 +1,14 @@
 """
 General utilities for llamaDAQ data decoding
 """
+
 from __future__ import annotations
 
 import logging
-from typing import Dict, Any
 
 log = logging.getLogger(__name__)
 
-#build a unique flat identifier for fadc and channel together
+
+# build a unique flat identifier for fadc and channel together
 def join_fadcid_chid(fadcid: int, chid: int) -> int:
     return (fadcid << 4) + chid
-

--- a/src/daq2lh5/llama/llama_event_decoder.py
+++ b/src/daq2lh5/llama/llama_event_decoder.py
@@ -99,7 +99,7 @@ class LLAMAEventDecoder(DataDecoder):
                     break
             else:
                 kll.append([fch_id])
-        log.debug("key lists is: {}".format(repr(kll)))
+        log.debug("key lists are: {}".format(repr(kll)))
         return kll
         
 
@@ -127,8 +127,6 @@ class LLAMAEventDecoder(DataDecoder):
         A single packet corresponds to a single event and channel, and has a unique timestamp.
         packets of different channel groups can vary in size!
         """
-
-        print("keys I got in decode_packet(): {}".format(evt_rbkd.keys()))
 
         # Check if this fch_id should be recorded.
         if fch_id not in evt_rbkd:
@@ -216,7 +214,6 @@ class LLAMAEventDecoder(DataDecoder):
         #store waveform if available:
         if raw_length_16 > 0:
             tbl["waveform"]["values"].nda[ii] = evt_data_16[offset * 2 : offset * 2 + raw_length_16]
-            log.debug("Stored {} raw samples".format(raw_length_16))
             offset += raw_length_32
         
         #store aux (avg) waveform if available:

--- a/src/daq2lh5/llama/llama_event_decoder.py
+++ b/src/daq2lh5/llama/llama_event_decoder.py
@@ -2,10 +2,10 @@ from __future__ import annotations
 
 import copy
 import logging
-from typing import Any, Dict
-import numpy as np
+from typing import Any
 
 import lgdo
+import numpy as np
 
 from ..data_decoder import DataDecoder
 from .llama_header_decoder import LLAMA_Channel_Configs_t
@@ -16,33 +16,37 @@ log = logging.getLogger(__name__)
 llama_decoded_values_template = {
     # packet index in file
     "packet_id": {"dtype": "uint32"},
-    #combined index of FADC and channel
+    # combined index of FADC and channel
     "fch_id": {"dtype": "uint32"},
     # time since epoch
     "timestamp": {"dtype": "uint64", "units": "clock_ticks"},
-    "status_flag": {"dtype": "uint32"}
+    "status_flag": {"dtype": "uint32"},
     # waveform data --> not always present
-    #"waveform": {
+    # "waveform": {
     #    "dtype": "uint16",
     #    "datatype": "waveform",
     #    "wf_len": 65532,  # max value. override this before initializing buffers to save RAM
     #    "dt": 8,  # override if a different clock rate is used
     #    "dt_units": "ns",
     #    "t0_units": "ns",
-    #}
+    # }
 }
-#"""Default llamaDAQ SIS3316 Event decoded values.
+# """Default llamaDAQ SIS3316 Event decoded values.
 #
-#Warning
-#-------
-#This configuration will be dynamically modified by the decoder at runtime.
-#"""
+# Warning
+# -------
+# This configuration will be dynamically modified by the decoder at runtime.
+# """
 
-def check_dict_spec_equal(d1: dict[str, Any], d2: dict[str, Any], specs: list[str]) -> bool:
+
+def check_dict_spec_equal(
+    d1: dict[str, Any], d2: dict[str, Any], specs: list[str]
+) -> bool:
     for spec in specs:
         if d1.get(spec) != d2.get(spec):
             return False
     return True
+
 
 class LLAMAEventDecoder(DataDecoder):
     """Decode llamaDAQ SIS3316 digitizer event data."""
@@ -54,9 +58,15 @@ class LLAMAEventDecoder(DataDecoder):
         super().__init__(*args, **kwargs)
         self.skipped_channels = {}
         self.channel_configs = None
-        self.dt_raw: dict[int, float] = {} # need to buffer that to update t0 for avg waveforms per event
-        self.t0_raw: dict[int, float] = {} # store when receiving channel configs and use for each waveform
-        self.t0_avg_const: dict[int, float] = {} #constant part of the t0 of averaged waveforms
+        self.dt_raw: dict[int, float] = (
+            {}
+        )  # need to buffer that to update t0 for avg waveforms per event
+        self.t0_raw: dict[int, float] = (
+            {}
+        )  # store when receiving channel configs and use for each waveform
+        self.t0_avg_const: dict[int, float] = (
+            {}
+        )  # constant part of the t0 of averaged waveforms
 
     def set_channel_configs(self, channel_configs: LLAMA_Channel_Configs_t) -> None:
         """Receive channel configurations from llama_streamer after header was parsed
@@ -68,18 +78,27 @@ class LLAMAEventDecoder(DataDecoder):
             format_bits = config["format_bits"]
             sample_clock_freq = config["sample_freq"]
             avg_mode = config["avg_mode"]
-            dt_raw: float = 1/sample_clock_freq*1000
+            dt_raw: float = 1 / sample_clock_freq * 1000
             dt_avg: float = dt_raw * (1 << (avg_mode + 1))
             # t0 generation functions from llamaDAQ -> EventConfig.hh
-            t0_raw: float = (float(config["sample_start_index"]) - float(config["sample_pretrigger"])) * dt_raw  # location of the trigger is at t = 0
-            t0_avg: float = -float(config["sample_pretrigger"]) * float(dt_raw) - float(config["avg_sample_pretrigger"]) * dt_avg  # additional offset to be added independently for every event
+            t0_raw: float = (
+                float(config["sample_start_index"]) - float(config["sample_pretrigger"])
+            ) * dt_raw  # location of the trigger is at t = 0
+            t0_avg: float = (
+                -float(config["sample_pretrigger"]) * float(dt_raw)
+                - float(config["avg_sample_pretrigger"]) * dt_avg
+            )  # additional offset to be added independently for every event
             self.dt_raw[fch] = dt_raw
             self.t0_raw[fch] = t0_raw
             self.t0_avg_const[fch] = t0_avg
             if config["sample_length"] > 0:
-                self.__add_waveform(self.decoded_values[fch], False, config["sample_length"], dt_raw)
+                self.__add_waveform(
+                    self.decoded_values[fch], False, config["sample_length"], dt_raw
+                )
             if config["avg_sample_length"] > 0 and avg_mode > 0:
-                self.__add_waveform(self.decoded_values[fch], True, config["avg_sample_length"], dt_avg)
+                self.__add_waveform(
+                    self.decoded_values[fch], True, config["avg_sample_length"], dt_avg
+                )
             if format_bits & 0x01:
                 self.__add_accum1till6(self.decoded_values[fch])
             if format_bits & 0x02:
@@ -95,13 +114,17 @@ class LLAMAEventDecoder(DataDecoder):
         Each inner list are the fch_id's which share the exact same settings (trace lengths, avg mode, ...),
         so they can end up in the same buffer.
         """
-        if self.channel_configs is None: 
-            raise RuntimeError("Identification of key lists requires channel configs to be set!")
+        if self.channel_configs is None:
+            raise RuntimeError(
+                "Identification of key lists requires channel configs to be set!"
+            )
 
         params_for_equality = ["sample_length", "avg_sample_length", "avg_mode"]
+
         def check_equal(c1, c2):
             return check_dict_spec_equal(c1, c2, params_for_equality)
-        kll: list[list[int]] = []      #key-list-list
+
+        kll: list[list[int]] = []  # key-list-list
         for fch_id, config in self.channel_configs.items():
             for kl in kll:
                 # use 1st entry of a list of list as "archetype"
@@ -110,11 +133,10 @@ class LLAMAEventDecoder(DataDecoder):
                     break
             else:
                 kll.append([fch_id])
-        log.debug("key lists are: {}".format(repr(kll)))
+        log.debug(f"key lists are: {repr(kll)}")
         return kll
-        
 
-    #copied from ORCA SIS3316
+    # copied from ORCA SIS3316
     def get_decoded_values(self, key: int = None) -> dict[str, Any]:
         if key is None:
             raise RuntimeError("Key is None!")
@@ -126,13 +148,15 @@ class LLAMAEventDecoder(DataDecoder):
         else:
             dec_vals_list = self.decoded_values[key]
             return dec_vals_list
-    
-    def decode_packet(self, packet: bytes, 
-            evt_rbkd: lgdo.Table | dict[int, lgdo.Table],
-            packet_id: int,
-            fch_id: int
-            #header: lgdo.Table | dict[int, lgdo.Table]
-            ) -> bool:
+
+    def decode_packet(
+        self,
+        packet: bytes,
+        evt_rbkd: lgdo.Table | dict[int, lgdo.Table],
+        packet_id: int,
+        fch_id: int,
+        # header: lgdo.Table | dict[int, lgdo.Table]
+    ) -> bool:
         """
         Decodes a single packet, which is a single SIS3316 event, as specified in the Struck manual.
         A single packet corresponds to a single event and channel, and has a unique timestamp.
@@ -147,7 +171,7 @@ class LLAMAEventDecoder(DataDecoder):
                 log.debug(f"evt_rbkd: {evt_rbkd.keys()}")
             self.skipped_channels[fch_id] += 1
             return False
-        
+
         tbl = evt_rbkd[fch_id].lgdo
         ii = evt_rbkd[fch_id].loc
 
@@ -156,9 +180,9 @@ class LLAMAEventDecoder(DataDecoder):
         evt_data_16 = np.frombuffer(packet, dtype=np.uint16)
 
         # e sti gran binaries non ce li metti
-        #fch_id = (evt_data_32[0] >> 4) & 0x00000fff  --> to be read earlier, since we need size for chopping out the event from the stream
-        timestamp = ((evt_data_32[0] & 0xffff0000) << 16) + evt_data_32[1]
-        format_bits = (evt_data_32[0]) & 0x0000000f
+        # fch_id = (evt_data_32[0] >> 4) & 0x00000fff  --> to be read earlier, since we need size for chopping out the event from the stream
+        timestamp = ((evt_data_32[0] & 0xFFFF0000) << 16) + evt_data_32[1]
+        format_bits = (evt_data_32[0]) & 0x0000000F
         tbl["fch_id"].nda[ii] = fch_id
         tbl["packet_id"].nda[ii] = packet_id
         tbl["timestamp"].nda[ii] = timestamp
@@ -166,48 +190,52 @@ class LLAMAEventDecoder(DataDecoder):
         if format_bits & 0x1:
             tbl["peakHighValue"].nda[ii] = evt_data_16[4]
             tbl["peakHighIndex"].nda[ii] = evt_data_16[5]
-            tbl["information"].nda[ii] = (evt_data_32[offset+1] >> 24) & 0xff
-            tbl["accSum1"].nda[ii] = evt_data_32[offset+2]
-            tbl["accSum2"].nda[ii] = evt_data_32[offset+3]
-            tbl["accSum3"].nda[ii] = evt_data_32[offset+4]
-            tbl["accSum4"].nda[ii] = evt_data_32[offset+5]
-            tbl["accSum5"].nda[ii] = evt_data_32[offset+6]
-            tbl["accSum6"].nda[ii] = evt_data_32[offset+7]
+            tbl["information"].nda[ii] = (evt_data_32[offset + 1] >> 24) & 0xFF
+            tbl["accSum1"].nda[ii] = evt_data_32[offset + 2]
+            tbl["accSum2"].nda[ii] = evt_data_32[offset + 3]
+            tbl["accSum3"].nda[ii] = evt_data_32[offset + 4]
+            tbl["accSum4"].nda[ii] = evt_data_32[offset + 5]
+            tbl["accSum5"].nda[ii] = evt_data_32[offset + 6]
+            tbl["accSum6"].nda[ii] = evt_data_32[offset + 7]
             offset += 7
         if format_bits & 0x2:
-            tbl["accSum7"].nda[ii] = evt_data_32[offset+0]
-            tbl["accSum8"].nda[ii] = evt_data_32[offset+1]
+            tbl["accSum7"].nda[ii] = evt_data_32[offset + 0]
+            tbl["accSum8"].nda[ii] = evt_data_32[offset + 1]
             offset += 2
         if format_bits & 0x4:
-            tbl["mawMax"].nda[ii] = evt_data_32[offset+0]
-            tbl["mawBefore"].nda[ii] = evt_data_32[offset+1]
-            tbl["mawAfter"].nda[ii] = evt_data_32[offset+2]
+            tbl["mawMax"].nda[ii] = evt_data_32[offset + 0]
+            tbl["mawBefore"].nda[ii] = evt_data_32[offset + 1]
+            tbl["mawAfter"].nda[ii] = evt_data_32[offset + 2]
             offset += 3
         if format_bits & 0x8:
-            tbl["startEnergy"].nda[ii] = evt_data_32[offset+0]
-            tbl["maxEnergy"].nda[ii] = evt_data_32[offset+1]
+            tbl["startEnergy"].nda[ii] = evt_data_32[offset + 0]
+            tbl["maxEnergy"].nda[ii] = evt_data_32[offset + 1]
             offset += 2
 
-        raw_length_32 = (evt_data_32[offset+0]) & 0x03ffffff
-        tbl["status_flag"].nda[ii] = ((evt_data_32[offset+0]) & 0x04000000) >> 26 #bit 26
-        maw_test_flag = ((evt_data_32[offset+0]) & 0x08000000) >> 27 #bit 27
+        raw_length_32 = (evt_data_32[offset + 0]) & 0x03FFFFFF
+        tbl["status_flag"].nda[ii] = (
+            (evt_data_32[offset + 0]) & 0x04000000
+        ) >> 26  # bit 26
+        maw_test_flag = ((evt_data_32[offset + 0]) & 0x08000000) >> 27  # bit 27
         avg_data_coming = False
-        if evt_data_32[offset+0] & 0xf0000000 == 0xe0000000:
+        if evt_data_32[offset + 0] & 0xF0000000 == 0xE0000000:
             avg_data_coming = False
-        elif evt_data_32[offset+0] & 0xf0000000 == 0xa0000000:
+        elif evt_data_32[offset + 0] & 0xF0000000 == 0xA0000000:
             avg_data_coming = True
         else:
             raise RuntimeError("Data corruption 1!")
-        offset += 1 
+        offset += 1
         avg_length_32 = 0
         if avg_data_coming:
-            avg_count_status = (evt_data_32[offset+0] & 0x00ff0000) >> 16  # bits 23 - 16
-            avg_length_32 = evt_data_32[offset+0] & 0x0000ffff
-            if evt_data_32[offset+0] & 0xf0000000 != 0xe0000000:
+            avg_count_status = (
+                evt_data_32[offset + 0] & 0x00FF0000
+            ) >> 16  # bits 23 - 16
+            avg_length_32 = evt_data_32[offset + 0] & 0x0000FFFF
+            if evt_data_32[offset + 0] & 0xF0000000 != 0xE0000000:
                 raise RuntimeError("Data corruption 2!")
             offset += 1
-        
-        # --- now the offset points to the raw wf data --- 
+
+        # --- now the offset points to the raw wf data ---
 
         if maw_test_flag:
             raise RuntimeError("Cannot handle data with MAW test data!")
@@ -220,30 +248,44 @@ class LLAMAEventDecoder(DataDecoder):
 
         # error check: waveform size must match expectations
         if raw_length_16 + avg_length_16 != expected_wf_length:
-            raise RuntimeError("Waveform sizes {} (raw) and {} (avg) doesn't match expected size {}.".format(raw_length_16, avg_length_16, expected_wf_length))
-        
-        #store waveform if available:
+            raise RuntimeError(
+                f"Waveform sizes {raw_length_16} (raw) and {avg_length_16} (avg) doesn't match expected size {expected_wf_length}."
+            )
+
+        # store waveform if available:
         if raw_length_16 > 0:
-            tbl["waveform"]["values"].nda[ii] = evt_data_16[offset * 2 : offset * 2 + raw_length_16]
+            tbl["waveform"]["values"].nda[ii] = evt_data_16[
+                offset * 2 : offset * 2 + raw_length_16
+            ]
             offset += raw_length_32
             tbl["waveform"]["t0"].nda[ii] = self.t0_raw[fch_id]
-        
-        #store pre-averaged (avg) waveform if available:
+
+        # store pre-averaged (avg) waveform if available:
         if avg_length_16 > 0:
-            tbl["avgwaveform"]["values"].nda[ii] = evt_data_16[offset * 2 : offset * 2 + avg_length_16]
+            tbl["avgwaveform"]["values"].nda[ii] = evt_data_16[
+                offset * 2 : offset * 2 + avg_length_16
+            ]
             offset += avg_length_32
             # need to update avg waveform t0 based on the offset I get per event
-            tbl["avgwaveform"]["t0"].nda[ii] = self.t0_avg_const[fch_id] + float(avg_count_status) * self.dt_raw[fch_id]
+            tbl["avgwaveform"]["t0"].nda[ii] = (
+                self.t0_avg_const[fch_id]
+                + float(avg_count_status) * self.dt_raw[fch_id]
+            )
 
         if offset != len(evt_data_32):
-            raise RuntimeError("I messed up...")     
+            raise RuntimeError("I messed up...")
 
         evt_rbkd[fch_id].loc += 1
 
         return evt_rbkd[fch_id].is_full()
 
-
-    def __add_waveform(self, decoded_values_fch: dict[str, Any], is_avg: bool, max_samples: int, dt: float) -> None:
+    def __add_waveform(
+        self,
+        decoded_values_fch: dict[str, Any],
+        is_avg: bool,
+        max_samples: int,
+        dt: float,
+    ) -> None:
         """
         Averaged samples are available from the 125 MHz (16 bit) variatnt of the SIS3316 and can be stored independently of raw samples.
         I use waveform for raw samples (dt from clock itself) and avgwaveform from averaged samples (dt from clock * avg number).
@@ -255,8 +297,8 @@ class LLAMAEventDecoder(DataDecoder):
             "dtype": "uint16",
             "datatype": "waveform",
             "wf_len": max_samples,  # max value. override this before initializing buffers to save RAM
-            "dt": dt, # the sample pitch (inverse of clock speed)
-            #"t0": t0, # Adding t0 here does not work
+            "dt": dt,  # the sample pitch (inverse of clock speed)
+            # "t0": t0, # Adding t0 here does not work
             "dt_units": "ns",
             "t0_units": "ns",
         }
@@ -284,4 +326,3 @@ class LLAMAEventDecoder(DataDecoder):
     def __add_energy(self, decoded_values_fch: dict[str, Any]) -> None:
         decoded_values_fch["startEnergy"] = {"dtype": "uint32", "units": "adc"}
         decoded_values_fch["maxEnergy"] = {"dtype": "uint32", "units": "adc"}
-

--- a/src/daq2lh5/llama/llama_event_decoder.py
+++ b/src/daq2lh5/llama/llama_event_decoder.py
@@ -1,0 +1,228 @@
+from __future__ import annotations
+
+import copy
+import logging
+from typing import Any, Dict
+import numpy as np
+
+import lgdo
+
+from ..data_decoder import DataDecoder
+from .llama_header_decoder import LLAMA_Channel_Configs_t
+
+log = logging.getLogger(__name__)
+
+# put decoded values here
+llama_decoded_values_template = {
+    # packet index in file
+    "packet_id": {"dtype": "uint32"},
+    #combined index of FADC and channel
+    "fch_id": {"dtype": "uint32"},
+    # time since epoch
+    "timestamp": {"dtype": "uint64", "units": "clock_ticks"}
+    # waveform data --> not always present
+    #"waveform": {
+    #    "dtype": "uint16",
+    #    "datatype": "waveform",
+    #    "wf_len": 65532,  # max value. override this before initializing buffers to save RAM
+    #    "dt": 8,  # override if a different clock rate is used
+    #    "dt_units": "ns",
+    #    "t0_units": "ns",
+    #}
+}
+"""Default llamaDAQ SIS3316 Event decoded values.
+
+Warning
+-------
+This configuration can be dynamically modified by the decoder at runtime.
+"""
+
+
+class LLAMAEventDecoder(DataDecoder):
+    """Decode llamaDAQ SIS3316 digitizer event data."""
+
+    def __init__(self, *args, **kwargs) -> None:
+        # these are read for every event (decode_event)
+        # One set of settings per fch, since settings can be different per channel group
+        self.decoded_values: dict[int, dict[str, Any]] = {}
+        super().__init__(*args, **kwargs)
+        self.skipped_channels = {}      # TODO
+        self.channel_configs = None
+
+    def set_channel_configs(self, channel_configs: LLAMA_Channel_Configs_t) -> None:
+        """Receive channel configurations from llama_streamer after header was parsed
+        Adapt self.decoded_values dict based on read configuration
+        """
+        self.channel_configs = channel_configs
+        for fch, config in self.channel_configs.items():
+            self.decoded_values[fch] = copy.deepcopy(llama_decoded_values_template)
+            format_bits = config["format_bits"]
+            sample_clock_freq = config["sample_freq"]
+            avg_mode = config["avg_mode"]
+            dt_raw: int = int(1/sample_clock_freq*1000 + 0.5)
+            dt_aux: int = dt_raw * (1 << (avg_mode + 1))
+            if config["sample_length"] > 0:
+                self.__add_waveform(self.decoded_values[fch], False, config["sample_length"], dt_raw)
+            if config["avg_sample_length"] > 0 and avg_mode > 0:
+                self.__add_waveform(self.decoded_values[fch], True, config["avg_sample_length"], dt_aux)
+            if format_bits & 0x01:
+                self.__add_accum1till6(self.decoded_values[fch])
+            if format_bits & 0x02:
+                self.__add_accum7and8(self.decoded_values[fch])
+            if format_bits & 0x04:
+                self.__add_maw(self.decoded_values[fch])
+            if format_bits & 0x08:
+                self.__add_energy(self.decoded_values[fch])
+
+    #copied from ORCA SIS3316
+    def get_decoded_values(self, key: int = None) -> dict[str, Any]:
+        if key is None:
+            dec_vals_list = self.decoded_values.values()
+            if len(dec_vals_list) == 0:
+                raise RuntimeError("decoded_values not built yet!")
+
+            return dec_vals_list  # Get first thing we find
+        else:
+            dec_vals_list = self.decoded_values[key]
+            return dec_vals_list
+    
+    def decode_packet(self, packet: bytes, 
+            evt_rbkd: lgdo.Table | dict[int, lgdo.Table],
+            packet_id: int,
+            fch_id: int
+            #header: lgdo.Table | dict[int, lgdo.Table]
+            ) -> bool:
+        """
+        Decodes a single packet, which is a single SIS3316 event, as specified in the Struck manual.
+        A single packet corresponds to a single event and channel, and has a unique timestamp.
+        packets of different channel groups can vary in size!
+        """
+
+        # parse the raw event data into numpy arrays of 16 and 32 bit ints
+        evt_data_32 = np.frombuffer(packet, dtype=np.uint32)
+        evt_data_16 = np.frombuffer(packet, dtype=np.uint16)
+
+        # e sti gran binaries non ce li metti
+        #fch_id = (evt_data_32[0] >> 4) & 0x00000fff  --> to be read earlier, since we need size for chopping out the event from the stream
+        timestamp = ((evt_data_32[0] & 0xffff0000) << 16) + evt_data_32[1]
+        format_bits = (evt_data_32[0]) & 0x0000000f
+        offset = 2
+        if format_bits & 0x1:
+            peakhigh_value = evt_data_16[4]
+            peakhigh_index = evt_data_16[5]
+            information = (evt_data_32[offset+1] >> 24) & 0xff
+            accumulator1 = evt_data_32[offset+2]
+            accumulator2 = evt_data_32[offset+3]
+            accumulator3 = evt_data_32[offset+4]
+            accumulator4 = evt_data_32[offset+5]
+            accumulator5 = evt_data_32[offset+6]
+            accumulator6 = evt_data_32[offset+7]
+            offset += 7
+        else:
+            peakhigh_value = 0
+            peakhigh_index = 0  
+            information = 0
+            accumulator1 = accumulator2 = accumulator3 = accumulator4 = accumulator5 = accumulator6 = 0
+            pass
+        if format_bits & 0x2:
+            accumulator7 = evt_data_32[offset+0]
+            accumulator8 = evt_data_32[offset+1]
+            offset += 2
+        else:
+            accumulator7 = accumulator8 = 0
+            pass
+        if format_bits & 0x4:
+            mawMax = evt_data_32[offset+0]
+            maw_before = evt_data_32[offset+1]
+            maw_after = evt_data_32[offset+2]
+            offset += 3
+        else:
+            mawMax = maw_before = maw_after = 0
+            pass
+        if format_bits & 0x8:
+            energy_first = evt_data_32[offset+0]
+            energy = evt_data_32[offset+1]
+            offset += 2
+        else:
+            energy_first = energy = 0
+            pass
+        raw_length_32 = (evt_data_32[offset+0]) & 0x03ffffff
+        status_flag = ((evt_data_32[offset+0]) & 0x04000000) >> 26 #bit 26
+        maw_test_flag = ((evt_data_32[offset+0]) & 0x08000000) >> 27 #bit 27
+        avg_data_coming = False
+        if evt_data_32[offset+0] & 0xf0000000 == 0xe0000000:
+            avg_data_coming = False
+        elif evt_data_32[offset+0] & 0xf0000000 == 0xa0000000:
+            avg_data_coming = True
+        else:
+            raise RuntimeError("Data corruption 1!")
+        offset += 1 
+        avg_length_32 = 0
+        if avg_data_coming:
+            avg_count_status = (evt_data_32[offset+0] & 0x00ff0000) >> 16  # bits 23 - 16
+            avg_length_32 = evt_data_32[offset+0] & 0x0000ffff
+            if evt_data_32[offset+0] & 0xf0000000 != 0xe0000000:
+                raise RuntimeError("Data corruption 2!")
+            offset += 1
+        
+        # --- now the offset points to the raw wf data --- 
+
+        if maw_test_flag:
+            raise RuntimeError("Cannot handle data with MAW test data!")
+
+        # compute expected and actual array dimensions
+        raw_length_16 = 2 * raw_length_32
+        avg_length_16 = 2 * avg_length_32
+        header_length_16 = offset * 2
+        expected_wf_length = len(evt_data_16) - header_length_16
+
+        # error check: waveform size must match expectations
+        if raw_length_16 + avg_length_16 != expected_wf_length:
+            raise RuntimeError("Waveform sizes {} (raw) and {} (avg) doesn't match expected size {}.".format(raw_length_16, avg_length_16, expected_wf_length))
+
+        print(f"Just read event for fch {fch_id}.")
+        print(f"ACC1 {accumulator1}, timestamp {timestamp} {raw_length_16}, {avg_length_16}")        
+
+        
+
+        return False
+
+
+    def __add_waveform(self, decoded_values_fch: dict[str, Any], is_aux: bool, max_samples: int, dt: int) -> None:
+        """
+        Averaged samples are called "Aux waveform" due to historic (GERDA) reasons.
+        """
+        name: str = "auxwaveform" if is_aux else "waveform"
+        decoded_values_fch[name] = {
+            "dtype": "uint16",
+            "datatype": "waveform",
+            "wf_len": max_samples,  # max value. override this before initializing buffers to save RAM
+            "dt": dt,  # override if a different clock rate is used
+            "dt_units": "ns",
+            "t0_units": "ns",
+        }
+
+    def __add_accum1till6(self, decoded_values_fch: dict[str, Any]) -> None:
+        decoded_values_fch["peakHighValue"] = {"dtype": "uint32", "units": "adc"}
+        decoded_values_fch["peakHighIndex"] = {"dtype": "uint32", "units": "adc"}
+        decoded_values_fch["information"] = {"dtype": "uint32"}
+        decoded_values_fch["accSum1"] = {"dtype": "uint32", "units": "adc"}
+        decoded_values_fch["accSum2"] = {"dtype": "uint32", "units": "adc"}
+        decoded_values_fch["accSum3"] = {"dtype": "uint32", "units": "adc"}
+        decoded_values_fch["accSum4"] = {"dtype": "uint32", "units": "adc"}
+        decoded_values_fch["accSum5"] = {"dtype": "uint32", "units": "adc"}
+        decoded_values_fch["accSum6"] = {"dtype": "uint32", "units": "adc"}
+
+    def __add_accum7and8(self, decoded_values_fch: dict[str, Any]) -> None:
+        decoded_values_fch["accSum7"] = {"dtype": "uint32", "units": "adc"}
+        decoded_values_fch["accSum8"] = {"dtype": "uint32", "units": "adc"}
+
+    def __add_maw(self, decoded_values_fch: dict[str, Any]) -> None:
+        decoded_values_fch["mawMax"] = {"dtype": "uint32", "units": "adc"}
+        decoded_values_fch["mawBefore"] = {"dtype": "uint32", "units": "adc"}
+        decoded_values_fch["mawAfter"] = {"dtype": "uint32", "units": "adc"}
+
+    def __add_energy(self, decoded_values_fch: dict[str, Any]) -> None:
+        decoded_values_fch["startEnergy"] = {"dtype": "uint32", "units": "adc"}
+        decoded_values_fch["maxEnergy"] = {"dtype": "uint32", "units": "adc"}
+

--- a/src/daq2lh5/llama/llama_event_decoder.py
+++ b/src/daq2lh5/llama/llama_event_decoder.py
@@ -37,6 +37,11 @@ Warning
 This configuration can be dynamically modified by the decoder at runtime.
 """
 
+def check_dict_spec_equal(d1: dict[str, Any], d2: dict[str, Any], specs: list[str]) -> bool:
+    for spec in specs:
+        if d1.get(spec) != d2.get(spec):
+            return False
+    return True
 
 class LLAMAEventDecoder(DataDecoder):
     """Decode llamaDAQ SIS3316 digitizer event data."""
@@ -74,9 +79,34 @@ class LLAMAEventDecoder(DataDecoder):
             if format_bits & 0x08:
                 self.__add_energy(self.decoded_values[fch])
 
+    def get_key_lists(self) -> list[list[int | str]]:
+        """
+        Return a list of lists of keys available for this decoder.
+        Each inner list are the fch_id's which share the exact same settings (trace lengths, avg mode, ...),
+        so they can end up in the same buffer.
+        """
+        if self.channel_configs is None: 
+            raise RuntimeError("Identification of key lists requires channel configs to be set!")
+
+        params_for_equality = ["sample_length", "avg_sample_length", "avg_mode"]
+        check_equal = lambda c1, c2: check_dict_spec_equal(c1, c2, params_for_equality)
+        kll: list[list[int]] = []      #key-list-list
+        for fch_id, config in self.channel_configs.items():
+            for kl in kll:
+                # use 1st entry of a list of list as "archetype"
+                if check_equal(config, self.channel_configs[kl[0]]):
+                    kl.append(fch_id)
+                    break
+            else:
+                kll.append([fch_id])
+        log.debug("key lists is: {}".format(repr(kll)))
+        return kll
+        
+
     #copied from ORCA SIS3316
     def get_decoded_values(self, key: int = None) -> dict[str, Any]:
         if key is None:
+            raise RuntimeError("Key is None!")
             dec_vals_list = self.decoded_values.values()
             if len(dec_vals_list) == 0:
                 raise RuntimeError("decoded_values not built yet!")
@@ -98,6 +128,20 @@ class LLAMAEventDecoder(DataDecoder):
         packets of different channel groups can vary in size!
         """
 
+        print("keys I got in decode_packet(): {}".format(evt_rbkd.keys()))
+
+        # Check if this fch_id should be recorded.
+        if fch_id not in evt_rbkd:
+            if fch_id not in self.skipped_channels:
+                self.skipped_channels[fch_id] = 0
+                log.info(f"Skipping channel: {fch_id}")
+                log.debug(f"evt_rbkd: {evt_rbkd.keys()}")
+            self.skipped_channels[fch_id] += 1
+            return False
+        
+        tbl = evt_rbkd[fch_id].lgdo
+        ii = evt_rbkd[fch_id].loc
+
         # parse the raw event data into numpy arrays of 16 and 32 bit ints
         evt_data_32 = np.frombuffer(packet, dtype=np.uint32)
         evt_data_16 = np.frombuffer(packet, dtype=np.uint16)
@@ -106,46 +150,35 @@ class LLAMAEventDecoder(DataDecoder):
         #fch_id = (evt_data_32[0] >> 4) & 0x00000fff  --> to be read earlier, since we need size for chopping out the event from the stream
         timestamp = ((evt_data_32[0] & 0xffff0000) << 16) + evt_data_32[1]
         format_bits = (evt_data_32[0]) & 0x0000000f
+        tbl["fch_id"].nda[ii] = fch_id
+        tbl["packet_id"].nda[ii] = packet_id
+        tbl["timestamp"].nda[ii] = timestamp
         offset = 2
         if format_bits & 0x1:
-            peakhigh_value = evt_data_16[4]
-            peakhigh_index = evt_data_16[5]
-            information = (evt_data_32[offset+1] >> 24) & 0xff
-            accumulator1 = evt_data_32[offset+2]
-            accumulator2 = evt_data_32[offset+3]
-            accumulator3 = evt_data_32[offset+4]
-            accumulator4 = evt_data_32[offset+5]
-            accumulator5 = evt_data_32[offset+6]
-            accumulator6 = evt_data_32[offset+7]
+            tbl["peakHighValue"].nda[ii] = evt_data_16[4]
+            tbl["peakHighIndex"].nda[ii] = evt_data_16[5]
+            tbl["information"].nda[ii] = (evt_data_32[offset+1] >> 24) & 0xff
+            tbl["accSum1"].nda[ii] = evt_data_32[offset+2]
+            tbl["accSum2"].nda[ii] = evt_data_32[offset+3]
+            tbl["accSum3"].nda[ii] = evt_data_32[offset+4]
+            tbl["accSum4"].nda[ii] = evt_data_32[offset+5]
+            tbl["accSum5"].nda[ii] = evt_data_32[offset+6]
+            tbl["accSum6"].nda[ii] = evt_data_32[offset+7]
             offset += 7
-        else:
-            peakhigh_value = 0
-            peakhigh_index = 0  
-            information = 0
-            accumulator1 = accumulator2 = accumulator3 = accumulator4 = accumulator5 = accumulator6 = 0
-            pass
         if format_bits & 0x2:
-            accumulator7 = evt_data_32[offset+0]
-            accumulator8 = evt_data_32[offset+1]
+            tbl["accSum7"].nda[ii] = evt_data_32[offset+0]
+            tbl["accSum8"].nda[ii] = evt_data_32[offset+1]
             offset += 2
-        else:
-            accumulator7 = accumulator8 = 0
-            pass
         if format_bits & 0x4:
-            mawMax = evt_data_32[offset+0]
-            maw_before = evt_data_32[offset+1]
-            maw_after = evt_data_32[offset+2]
+            tbl["mawMax"].nda[ii] = evt_data_32[offset+0]
+            tbl["mawBefore"].nda[ii] = evt_data_32[offset+1]
+            tbl["mawAfter"].nda[ii] = evt_data_32[offset+2]
             offset += 3
-        else:
-            mawMax = maw_before = maw_after = 0
-            pass
         if format_bits & 0x8:
-            energy_first = evt_data_32[offset+0]
-            energy = evt_data_32[offset+1]
+            tbl["startEnergy"].nda[ii] = evt_data_32[offset+0]
+            tbl["maxEnergy"].nda[ii] = evt_data_32[offset+1]
             offset += 2
-        else:
-            energy_first = energy = 0
-            pass
+
         raw_length_32 = (evt_data_32[offset+0]) & 0x03ffffff
         status_flag = ((evt_data_32[offset+0]) & 0x04000000) >> 26 #bit 26
         maw_test_flag = ((evt_data_32[offset+0]) & 0x08000000) >> 27 #bit 27
@@ -179,13 +212,24 @@ class LLAMAEventDecoder(DataDecoder):
         # error check: waveform size must match expectations
         if raw_length_16 + avg_length_16 != expected_wf_length:
             raise RuntimeError("Waveform sizes {} (raw) and {} (avg) doesn't match expected size {}.".format(raw_length_16, avg_length_16, expected_wf_length))
-
-        print(f"Just read event for fch {fch_id}.")
-        print(f"ACC1 {accumulator1}, timestamp {timestamp} {raw_length_16}, {avg_length_16}")        
-
         
+        #store waveform if available:
+        if raw_length_16 > 0:
+            tbl["waveform"]["values"].nda[ii] = evt_data_16[offset * 2 : offset * 2 + raw_length_16]
+            log.debug("Stored {} raw samples".format(raw_length_16))
+            offset += raw_length_32
+        
+        #store aux (avg) waveform if available:
+        if avg_length_16 > 0:
+            tbl["auxwaveform"]["values"].nda[ii] = evt_data_16[offset * 2 : offset * 2 + avg_length_16]
+            offset += avg_length_32
 
-        return False
+        if offset != len(evt_data_32):
+            raise RuntimeError("I messed up...")     
+
+        evt_rbkd[fch_id].loc += 1
+
+        return evt_rbkd[fch_id].is_full()
 
 
     def __add_waveform(self, decoded_values_fch: dict[str, Any], is_aux: bool, max_samples: int, dt: int) -> None:

--- a/src/daq2lh5/llama/llama_event_decoder.py
+++ b/src/daq2lh5/llama/llama_event_decoder.py
@@ -53,6 +53,9 @@ class LLAMAEventDecoder(DataDecoder):
         super().__init__(*args, **kwargs)
         self.skipped_channels = {}
         self.channel_configs = None
+        self.dt_raw: dict[int, int] = {} # need to buffer that to update t0 for avg waveforms per event
+        self.t0_raw: dict[int, float] = {} # store when receiving channel configs and use for each waveform
+        self.t0_avg_const: dict[int, float] = {} #constant part of the t0 of averaged waveforms
 
     def set_channel_configs(self, channel_configs: LLAMA_Channel_Configs_t) -> None:
         """Receive channel configurations from llama_streamer after header was parsed
@@ -66,6 +69,12 @@ class LLAMAEventDecoder(DataDecoder):
             avg_mode = config["avg_mode"]
             dt_raw: int = int(1/sample_clock_freq*1000 + 0.5)
             dt_avg: int = dt_raw * (1 << (avg_mode + 1))
+            # t0 generation functions from llamaDAQ -> EventConfig.hh
+            t0_raw: float = (float(config["sample_start_index"]) - float(config["sample_pretrigger"])) * float(dt_raw)  # location of the trigger is at t = 0
+            t0_avg: float = -float(config["sample_pretrigger"]) * float(dt_raw) - float(config["avg_sample_pretrigger"]) * float(dt_avg)  # additional offset to be added independently for every event
+            self.dt_raw[fch] = dt_raw
+            self.t0_raw[fch] = t0_raw
+            self.t0_avg_const[fch] = t0_avg
             if config["sample_length"] > 0:
                 self.__add_waveform(self.decoded_values[fch], False, config["sample_length"], dt_raw)
             if config["avg_sample_length"] > 0 and avg_mode > 0:
@@ -215,11 +224,14 @@ class LLAMAEventDecoder(DataDecoder):
         if raw_length_16 > 0:
             tbl["waveform"]["values"].nda[ii] = evt_data_16[offset * 2 : offset * 2 + raw_length_16]
             offset += raw_length_32
+            tbl["waveform"]["t0"].nda[ii] = self.t0_raw[fch_id]
         
         #store pre-averaged (avg) waveform if available:
         if avg_length_16 > 0:
             tbl["avgwaveform"]["values"].nda[ii] = evt_data_16[offset * 2 : offset * 2 + avg_length_16]
             offset += avg_length_32
+            # need to update avg waveform t0 based on the offset I get per event
+            tbl["avgwaveform"]["t0"].nda[ii] = self.t0_avg_const[fch_id] + float(avg_count_status) * float(self.dt_raw[fch_id])
 
         if offset != len(evt_data_32):
             raise RuntimeError("I messed up...")     
@@ -241,7 +253,8 @@ class LLAMAEventDecoder(DataDecoder):
             "dtype": "uint16",
             "datatype": "waveform",
             "wf_len": max_samples,  # max value. override this before initializing buffers to save RAM
-            "dt": dt,  # override if a different clock rate is used
+            "dt": dt, # the sample pitch (inverse of clock speed)
+            #"t0": t0, # Adding t0 here does not work
             "dt_units": "ns",
             "t0_units": "ns",
         }

--- a/src/daq2lh5/llama/llama_header_decoder.py
+++ b/src/daq2lh5/llama/llama_header_decoder.py
@@ -40,12 +40,11 @@ class LLAMAHeaderDecoder(DataDecoder):  # DataDecoder currently unused
 
         #line0: magic bytes
         magic = evt_data_32[0]
-        print(hex(magic))
+        #print(hex(magic))
         if magic == self.magic_bytes():
-            if self.verbose > 0:
-                print ("Read in file as llamaDAQ-SIS3316, magic bytes correct.")
+            log.info("Read in file as llamaDAQ-SIS3316, magic bytes correct.")
         else:
-            print ("ERROR: Magic bytes not matching for llamaDAQ file!")
+            log.error("Magic bytes not matching for llamaDAQ file!")
             raise RuntimeError("wrong file type")
     
         self.version_major = evt_data_16[4]
@@ -54,9 +53,8 @@ class LLAMAHeaderDecoder(DataDecoder):  # DataDecoder currently unused
         self.length_econf = evt_data_16[5]
         self.number_chOpen = evt_data_32[3]
         
-        if self.verbose > 0:
-            print ("File version: {}.{}.{}".format(self.version_major, self.version_minor, self.version_patch))
-            print ("{} channels open, each config {} bytes long".format(self.number_chOpen, self.length_econf))
+        log.debug("File version: {}.{}.{}".format(self.version_major, self.version_minor, self.version_patch))
+        log.debug("{} channels open, each config {} bytes long".format(self.number_chOpen, self.length_econf))
 
         n_bytes_read += self.__decode_channelConfigs(f_in)
 

--- a/src/daq2lh5/llama/llama_header_decoder.py
+++ b/src/daq2lh5/llama/llama_header_decoder.py
@@ -1,0 +1,143 @@
+from __future__ import annotations
+
+import logging
+import io
+import numpy as np
+from typing import Dict, Any
+
+import lgdo
+
+from ..data_decoder import DataDecoder
+
+log = logging.getLogger(__name__)
+
+
+class LLAMAHeaderDecoder(DataDecoder):  # DataDecoder currently unused
+    """
+    Decode llamaDAQ header data. Includes the file header as well as all available ("open") channel configurations.
+    """
+
+    @staticmethod
+    def magic_bytes() -> int:
+        return 0x4972414c
+
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        self.config = lgdo.Struct()
+        self.channel_configs = None
+        self.verbose = True ### debug
+
+    def decode_header(self, f_in: io.BufferedReader) -> lgdo.Struct:
+        n_bytes_read = 0
+
+        f_in.seek(0)    #should be there anyhow, but re-set if not
+        header = f_in.read(16) #read 16 bytes
+        n_bytes_read += 16
+        evt_data_32 = np.fromstring(header, dtype=np.uint32)
+        evt_data_16 = np.fromstring(header, dtype=np.uint16)
+
+        #line0: magic bytes
+        magic = evt_data_32[0]
+        print(hex(magic))
+        if magic == self.magic_bytes():
+            if self.verbose > 0:
+                print ("Read in file as llamaDAQ-SIS3316, magic bytes correct.")
+        else:
+            print ("ERROR: Magic bytes not matching for llamaDAQ file!")
+            raise RuntimeError("wrong file type")
+    
+        self.version_major = evt_data_16[4]
+        self.version_minor = evt_data_16[3]
+        self.version_patch = evt_data_16[2]
+        self.length_econf = evt_data_16[5]
+        self.number_chOpen = evt_data_32[3]
+        
+        if self.verbose > 0:
+            print ("File version: {}.{}.{}".format(self.version_major, self.version_minor, self.version_patch))
+            print ("{} channels open, each config {} bytes long".format(self.number_chOpen, self.length_econf))
+
+        n_bytes_read += self.__decode_channelConfigs(f_in)
+
+        print(self.channel_configs[0][0]["MAW3_offset"])
+
+        return self.config, n_bytes_read
+    
+    #override from DataDecoder
+    def make_lgdo(self, key: int = None, size: int = None) -> lgdo.Struct:
+        return self.config
+    
+
+    def __decode_channelConfigs(self, f_in: io.BufferedReader) -> int:
+        """
+        Reads the metadata from the beginning of the file (the "channel configuration" part, directly after the file header).
+        Creates a dictionary of the metadata for each FADC/channel combination, which is returned
+        
+        structure of channelConfigs:
+        FADCindex      channelIndex
+        A ------------- x ----------- metadata for FADC A channel x
+                      | y ----------- metadata for FADC A channel y
+                      | z ----------- metadata for FADC A channel z
+                      
+        B ------------- k ----------- metadata for FADC B channel k
+                      | l ----------- metadata for FADC B channel l
+        ...
+                      
+        returns number of bytes read
+        """
+        #f_in.seek(16)    #should be after file header anyhow, but re-set if not
+        n_bytes_read = 0
+        self.channel_configs = {}
+
+        if self.length_econf != 88:
+            raise RuntimeError("Invalid channel configuration format")
+
+        for i in range(0, self.number_chOpen):
+            if self.verbose > 1:
+                print("reading in channel config {}".format(i))
+                
+            channel = f_in.read(self.length_econf)
+            n_bytes_read += self.length_econf
+            ch_dpf = channel[16:32]
+            evt_data_32 = np.fromstring(channel, dtype=np.uint32)
+            evt_data_dpf = np.fromstring(ch_dpf, dtype=np.float64)
+            
+            fadcIndex = evt_data_32[0]
+            channelIndex = evt_data_32[1]
+            
+            if fadcIndex in self.channel_configs:
+                #print("pre-existing fadc")
+                pass
+            else:
+                #print("new fadc #{}".format(fadcIndex))
+                self.channel_configs[fadcIndex] = {}
+    
+            if channelIndex in self.channel_configs[fadcIndex]:
+                raise RuntimeError("duplicate channel configuration in file: FADCID: {}, ChannelID: {}".format(fadcIndex, channelIndex))
+            else:
+                self.channel_configs[fadcIndex][channelIndex] = {}
+                
+            self.channel_configs[fadcIndex][channelIndex]["14BitFlag"] = evt_data_32[2] & 0x00000001
+            if evt_data_32[2] & 0x00000002 == 0:
+                print("WARNING: Channel in configuration marked as non-open!")
+            self.channel_configs[fadcIndex][channelIndex]["ADC_offset"] = evt_data_32[3]
+            self.channel_configs[fadcIndex][channelIndex]["sample_freq"] = evt_data_dpf[0]     #64 bit float
+            self.channel_configs[fadcIndex][channelIndex]["gain"] = evt_data_dpf[1]
+            self.channel_configs[fadcIndex][channelIndex]["format_bits"] = evt_data_32[8]
+            self.channel_configs[fadcIndex][channelIndex]["sample_start_index"] = evt_data_32[9]
+            self.channel_configs[fadcIndex][channelIndex]["sample_pretrigger"] = evt_data_32[10]
+            self.channel_configs[fadcIndex][channelIndex]["avg_sample_pretrigger"] = evt_data_32[11]
+            self.channel_configs[fadcIndex][channelIndex]["avg_mode"] = evt_data_32[12]
+            self.channel_configs[fadcIndex][channelIndex]["sample_length"] = evt_data_32[13]
+            self.channel_configs[fadcIndex][channelIndex]["avg_sample_length"] = evt_data_32[14]
+            self.channel_configs[fadcIndex][channelIndex]["MAW_buffer_length"] = evt_data_32[15]
+            self.channel_configs[fadcIndex][channelIndex]["event_length"] = evt_data_32[16]
+            self.channel_configs[fadcIndex][channelIndex]["event_header_length"] = evt_data_32[17]
+            self.channel_configs[fadcIndex][channelIndex]["accum6_offset"] = evt_data_32[18]
+            self.channel_configs[fadcIndex][channelIndex]["accum2_offset"] = evt_data_32[19]
+            self.channel_configs[fadcIndex][channelIndex]["MAW3_offset"] = evt_data_32[20]
+            self.channel_configs[fadcIndex][channelIndex]["energy_offset"] = evt_data_32[21]
+
+        return n_bytes_read
+
+
+            

--- a/src/daq2lh5/llama/llama_header_decoder.py
+++ b/src/daq2lh5/llama/llama_header_decoder.py
@@ -12,6 +12,7 @@ from .llama_base import join_fadcid_chid
 
 log = logging.getLogger(__name__)
 
+LLAMA_Channel_Configs_t = Dict[int, Dict[str, Any]]
 
 class LLAMAHeaderDecoder(DataDecoder):  # DataDecoder currently unused
     """
@@ -59,7 +60,7 @@ class LLAMAHeaderDecoder(DataDecoder):  # DataDecoder currently unused
 
         n_bytes_read += self.__decode_channelConfigs(f_in)
 
-        print(self.channel_configs[0]["MAW3_offset"])
+        #print(self.channel_configs[0]["MAW3_offset"])
 
         # assemble LGDO struct:
         self.config.add_field("version_major", lgdo.Scalar(self.version_major))
@@ -81,6 +82,8 @@ class LLAMAHeaderDecoder(DataDecoder):  # DataDecoder currently unused
     def make_lgdo(self, key: int = None, size: int = None) -> lgdo.Struct:
         return self.config
     
+    def get_channel_configs(self) -> LLAMA_Channel_Configs_t:
+        return self.channel_configs
 
     def __decode_channelConfigs(self, f_in: io.BufferedReader) -> int:
         """
@@ -106,8 +109,8 @@ class LLAMAHeaderDecoder(DataDecoder):  # DataDecoder currently unused
             channel = f_in.read(self.length_econf)
             n_bytes_read += self.length_econf
             ch_dpf = channel[16:32]
-            evt_data_32 = np.fromstring(channel, dtype=np.uint32)
-            evt_data_dpf = np.fromstring(ch_dpf, dtype=np.float64)
+            evt_data_32 = np.frombuffer(channel, dtype=np.uint32)
+            evt_data_dpf = np.frombuffer(ch_dpf, dtype=np.float64)
             
             fadcIndex = evt_data_32[0]
             channelIndex = evt_data_32[1]

--- a/src/daq2lh5/llama/llama_header_decoder.py
+++ b/src/daq2lh5/llama/llama_header_decoder.py
@@ -60,6 +60,23 @@ class LLAMAHeaderDecoder(DataDecoder):  # DataDecoder currently unused
 
         print(self.channel_configs[0][0]["MAW3_offset"])
 
+        # assemble LGDO struct:
+        self.config.add_field("version_major", self.version_major)
+        self.config.add_field("version_minor", self.version_minor)
+        self.config.add_field("version_patch", self.version_patch)
+        self.config.add_field("length_econf", self.length_econf)
+        self.config.add_field("number_chOpen", self.number_chOpen)
+        
+        for fadcid, fadc in self.channel_configs.items():
+            fadc_lgdo = lgdo.Struct()
+            for chid, ch in fadc.items():
+                ch_lgdo = lgdo.Struct()
+                for key, value in ch.items():
+                    ch_lgdo.add_field(key, value)
+                fadc_lgdo.add_field("ch_{:02d}".format(chid), ch_lgdo)
+            self.config.add_field("fadc_{:02d}".format(fadcid), fadc_lgdo)
+
+
         return self.config, n_bytes_read
     
     #override from DataDecoder

--- a/src/daq2lh5/llama/llama_header_decoder.py
+++ b/src/daq2lh5/llama/llama_header_decoder.py
@@ -103,7 +103,7 @@ class LLAMAHeaderDecoder(DataDecoder):  # DataDecoder currently unused
         if self.length_econf != 88:
             raise RuntimeError("Invalid channel configuration format")
 
-        for i in range(0, self.number_chOpen):
+        for _i in range(0, self.number_chOpen):
             # print("reading in channel config {}".format(i))
 
             channel = f_in.read(self.length_econf)

--- a/src/daq2lh5/llama/llama_header_decoder.py
+++ b/src/daq2lh5/llama/llama_header_decoder.py
@@ -61,18 +61,18 @@ class LLAMAHeaderDecoder(DataDecoder):  # DataDecoder currently unused
         print(self.channel_configs[0][0]["MAW3_offset"])
 
         # assemble LGDO struct:
-        self.config.add_field("version_major", self.version_major)
-        self.config.add_field("version_minor", self.version_minor)
-        self.config.add_field("version_patch", self.version_patch)
-        self.config.add_field("length_econf", self.length_econf)
-        self.config.add_field("number_chOpen", self.number_chOpen)
+        self.config.add_field("version_major", lgdo.Scalar(self.version_major))
+        self.config.add_field("version_minor", lgdo.Scalar(self.version_minor))
+        self.config.add_field("version_patch", lgdo.Scalar(self.version_patch))
+        self.config.add_field("length_econf", lgdo.Scalar(self.length_econf))
+        self.config.add_field("number_chOpen", lgdo.Scalar(self.number_chOpen))
         
         for fadcid, fadc in self.channel_configs.items():
             fadc_lgdo = lgdo.Struct()
             for chid, ch in fadc.items():
                 ch_lgdo = lgdo.Struct()
                 for key, value in ch.items():
-                    ch_lgdo.add_field(key, value)
+                    ch_lgdo.add_field(key, lgdo.Scalar(value))
                 fadc_lgdo.add_field("ch_{:02d}".format(chid), ch_lgdo)
             self.config.add_field("fadc_{:02d}".format(fadcid), fadc_lgdo)
 

--- a/src/daq2lh5/llama/llama_streamer.py
+++ b/src/daq2lh5/llama/llama_streamer.py
@@ -61,6 +61,20 @@ class LLAMAStreamer(DataStreamer):
         if rb_lib is None:
             rb_lib = self.rb_lib
 
+        #print(rb_lib)
+
+        if "LLAMAHeaderDecoder" in rb_lib:
+            config_rb_list = rb_lib["LLAMAHeaderDecoder"]
+            if len(config_rb_list) != 1:
+                log.warning(
+                    f"config_rb_list had length {len(config_rb_list)}, ignoring all but the first"
+                )
+            rb = config_rb_list[0]
+        else:
+            rb = RawBuffer(lgdo=header)
+        rb.loc = 1  # we have filled this buffer
+        return [rb]
+
         
 
 

--- a/src/daq2lh5/llama/llama_streamer.py
+++ b/src/daq2lh5/llama/llama_streamer.py
@@ -81,7 +81,6 @@ class LLAMAStreamer(DataStreamer):
             if "LLAMAEventDecoder" in rb_lib
             else None
         )
-        #print(self.event_rbkd)
 
         if "LLAMAHeaderDecoder" in rb_lib:
             config_rb_list = rb_lib["LLAMAHeaderDecoder"]
@@ -119,7 +118,6 @@ class LLAMAStreamer(DataStreamer):
             return False        # EOF
         self.packet_id += 1
         self.n_bytes_read += len(packet)
-        print(f"Read another {len(packet)} bytes; now at {self.n_bytes_read}")
 
         self.any_full |= self.event_decoder.decode_packet(
             packet, self.event_rbkd, self.packet_id, fch_id
@@ -153,37 +151,5 @@ class LLAMAStreamer(DataStreamer):
 
         return packet, fch_id
     
-
-    ## unneeded, since apparently the base implementation already does this -> use get_key_lists() !
-    def build_default_rb_lib_XXX(self, out_stream: str, channel_configs: LLAMA_Channel_Configs_t) -> RawBufferLibrary:
-        """
-        Build a very basic :class:`~.RawBufferLibrary` that will work for this stream.
-        Similar to data_streamer.build_default_rb_lib()
-
-        Base method cannot be used, since we need different buffers for some different channels, since
-        data setup (length of traces, frequency of aux trace, ...) can change between channels.
-        """
-        rb_lib = RawBufferLibrary()
-        decoders = [self.event_decoder]
-        if len(decoders) == 0:
-            log.warning(
-                f"no decoders returned by get_decoder_list() for {type(self).__name__}"
-            )
-            return rb_lib
-
-
-
-    ## OLD, now unused try of that hack :)
-    def __hack_rb_lib(self, channel_configs):
-        rb_json = {
-            "LLAMAEventDecoder" : {
-                "events" : {
-                    "key_list" : [0,1,2],    #test
-                    "out_stream" : "test.lh5"
-                }
-            }
-        }
-        return RawBufferLibrary(rb_json)
-
 
 

--- a/src/daq2lh5/llama/llama_streamer.py
+++ b/src/daq2lh5/llama/llama_streamer.py
@@ -61,7 +61,7 @@ class LLAMAStreamer(DataStreamer):
         if rb_lib is None:
             rb_lib = self.rb_lib
 
-        #print(rb_lib)
+        print(header)
 
         if "LLAMAHeaderDecoder" in rb_lib:
             config_rb_list = rb_lib["LLAMAHeaderDecoder"]

--- a/src/daq2lh5/llama/llama_streamer.py
+++ b/src/daq2lh5/llama/llama_streamer.py
@@ -1,12 +1,15 @@
 from __future__ import annotations
 
 import logging
+from typing import Tuple
+import numpy as np
 
 from ..data_decoder import DataDecoder
 from ..data_streamer import DataStreamer
 from ..raw_buffer import RawBuffer, RawBufferLibrary
 
 from .llama_header_decoder import LLAMAHeaderDecoder
+from .llama_event_decoder import LLAMAEventDecoder
 
 log = logging.getLogger(__name__)
 
@@ -18,7 +21,9 @@ class LLAMAStreamer(DataStreamer):
     def __init__(self) -> None:
         super().__init__()
         self.in_stream = None
+        self.event_rbkd = None
         self.header_decoder = LLAMAHeaderDecoder()
+        self.event_decoder = LLAMAEventDecoder()
 
     def get_decoder_list(self) -> list[DataDecoder]:
         dec_list = []
@@ -44,10 +49,13 @@ class LLAMAStreamer(DataStreamer):
             raise RuntimeError("tried to open stream while previous one still open")
         self.in_stream = open(llama_filename.encode("utf-8"), "rb")
         self.n_bytes_read = 0
+        self.packet_id = 0
 
         # read header info here
         header, n_bytes_hdr = self.header_decoder.decode_header(self.in_stream)
         self.n_bytes_read += n_bytes_hdr
+
+        self.event_decoder.set_channel_configs(self.header_decoder.get_channel_configs())
 
         # initialize the buffers in rb_lib. Store them for fast lookup
         # Docu tells me to use initialize instead, but that does not exits (?)
@@ -61,7 +69,11 @@ class LLAMAStreamer(DataStreamer):
         if rb_lib is None:
             rb_lib = self.rb_lib
 
-        print(header)
+        self.event_rbkd = (
+            rb_lib["LLAMAEventDecoder"].get_keyed_dict()
+            if "LLAMAEventDecoder" in rb_lib
+            else None
+        )
 
         if "LLAMAHeaderDecoder" in rb_lib:
             config_rb_list = rb_lib["LLAMAHeaderDecoder"]
@@ -93,4 +105,44 @@ class LLAMAStreamer(DataStreamer):
         still_has_data
             returns `True` while there is still data to read.
         """
-        return False
+
+        packet, fch_id = self.__read_bytes()
+        if packet is None:
+            return False        # EOF
+        self.packet_id += 1
+        self.n_bytes_read += len(packet)
+
+        self.any_full |= self.event_decoder.decode_packet(
+            packet, self.event_rbkd, self.packet_id, fch_id
+        )
+
+        return True
+    
+    def __read_bytes(self) -> Tuple[bytes | None, int]:
+        """
+        return bytes if read successful or None if EOF.
+        int is the fch_id (needs to be fetched to obtain the size of the event)
+        """
+        if self.in_stream is None:
+            raise RuntimeError("No stream open!")
+
+        position = self.in_stream.tell()     #save position of the event header's 1st byte
+        data1 = self.in_stream.read(4)       #read the first (32 bit) word of the event's header: channelID & format bits
+        if len(data1) < 4:
+            return None, -1         # EOF, I guess
+        self.in_stream.seek(position)        #go back to 1st position of event header
+
+        header_data_32 = np.fromstring(data1, dtype=np.uint32)
+        fch_id = (header_data_32[0] >> 4) & 0x00000fff
+
+        event_length_32 = self.header_decoder.get_channel_configs()[fch_id]["event_length"]
+        event_length_8 = event_length_32 * 4
+
+        packet = self.in_stream.read(event_length_8)
+        if len(packet) < event_length_8:
+            raise RuntimeError(f"Tried to read {event_length_8} bytes but got {len(packet)}")
+
+        return packet, fch_id
+
+
+

--- a/src/daq2lh5/llama/llama_streamer.py
+++ b/src/daq2lh5/llama/llama_streamer.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import logging
+
+from ..data_decoder import DataDecoder
+from ..data_streamer import DataStreamer
+from ..raw_buffer import RawBuffer, RawBufferLibrary
+
+from .llama_header_decoder import LLAMAHeaderDecoder
+
+log = logging.getLogger(__name__)
+
+class LLAMAStreamer(DataStreamer):
+    """
+    Decode SIS3316 data acquired using llamaDAQ.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.in_stream = None
+        self.header_decoder = LLAMAHeaderDecoder()
+
+    def get_decoder_list(self) -> list[DataDecoder]:
+        dec_list = []
+        dec_list.append(self.header_decoder)
+        return dec_list
+    
+    def open_stream(
+        self,
+        llama_filename: str,
+        rb_lib: RawBufferLibrary = None,
+        buffer_size: int = 8192,
+        chunk_mode: str = "any_full",
+        out_stream: str = "",
+    ) -> list[RawBuffer]:
+        """Initialize the LLAMA data stream.
+
+        Refer to the documentation for
+        :meth:`.data_streamer.DataStreamer.open_stream` for a description
+        of the parameters.
+        """
+
+        if self.in_stream is not None:
+            raise RuntimeError("tried to open stream while previous one still open")
+        self.in_stream = open(llama_filename.encode("utf-8"), "rb")
+        self.n_bytes_read = 0
+
+        # read header info here
+        header, n_bytes_hdr = self.header_decoder.decode_header(self.in_stream)
+        self.n_bytes_read += n_bytes_hdr
+
+        # initialize the buffers in rb_lib. Store them for fast lookup
+        # Docu tells me to use initialize instead, but that does not exits (?)
+        super().open_stream(
+            llama_filename,
+            rb_lib,
+            buffer_size=buffer_size,
+            chunk_mode=chunk_mode,
+            out_stream=out_stream,
+        )
+        if rb_lib is None:
+            rb_lib = self.rb_lib
+
+        
+
+
+
+    def close_stream(self) -> None:
+        if self.in_stream is None:
+            raise RuntimeError("tried to close an unopened stream")
+        self.in_stream.close()
+        self.in_stream = None
+
+    def read_packet(self) -> bool:
+        """Reads a single packet's worth of data in to the :class:`.RawBufferLibrary`.
+
+        Returns
+        -------
+        still_has_data
+            returns `True` while there is still data to read.
+        """
+        return False

--- a/src/daq2lh5/logging.py
+++ b/src/daq2lh5/logging.py
@@ -11,6 +11,7 @@ ERROR = logging.ERROR
 FATAL = logging.FATAL
 CRITICAL = logging.CRITICAL
 
+root=logging.root
 
 def setup(level: int = logging.INFO, logger: logging.Logger = None) -> None:
     """Setup a colorful logging output.

--- a/src/daq2lh5/logging.py
+++ b/src/daq2lh5/logging.py
@@ -11,7 +11,8 @@ ERROR = logging.ERROR
 FATAL = logging.FATAL
 CRITICAL = logging.CRITICAL
 
-root=logging.root
+root = logging.root
+
 
 def setup(level: int = logging.INFO, logger: logging.Logger = None) -> None:
     """Setup a colorful logging output.


### PR DESCRIPTION
Added a decoder for raw data created by llamaDAQ reading out a SIS3316 FADC.

Can decode header data (accumulators, etc), raw samples & averaged samples.
Averaged samples can come from the SIS3316-16 version (hardware averaging) or emulated by llamaDAQ.

Raw data has to be produced in the "improved" or "emulated" (v2.1.0+) formats of llamaDAQ.

Fixed missing pyyaml and broken debug logger on the way...
