### PR TITLE
Replace pyfcutils by fcio-py. Add support for new Orca Decoders based on packaged fcio stream.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -32,11 +32,11 @@ classifiers =
 packages = find:
 install_requires =
     dspeed>=1.3.0a4
+    fcio
     h5py>=3.2.0
     hdf5plugin
     legend-pydataobj>=1.6
     numpy>=1.21
-    fcio
     pyyaml
     tqdm>=4.27
     xmltodict

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,7 +32,7 @@ classifiers =
 packages = find:
 install_requires =
     dspeed>=1.3.0a4
-    fcio>=0.7.3
+    fcio>=0.7.4
     h5py>=3.2.0
     hdf5plugin
     legend-pydataobj>=1.6

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,7 +32,7 @@ classifiers =
 packages = find:
 install_requires =
     dspeed>=1.3.0a4
-    fcio
+    fcio>=0.7.3
     h5py>=3.2.0
     hdf5plugin
     legend-pydataobj>=1.6

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,7 +36,7 @@ install_requires =
     hdf5plugin
     legend-pydataobj>=1.6
     numpy>=1.21
-    pyfcutils
+    fcio
     pyyaml
     tqdm>=4.27
     xmltodict

--- a/src/daq2lh5/build_raw.py
+++ b/src/daq2lh5/build_raw.py
@@ -200,7 +200,7 @@ def build_raw(
         in_stream,
         rb_lib=rb_lib,
         buffer_size=buffer_size,
-        chunk_mode="full_only",
+        chunk_mode="only_full",
         out_stream=out_stream,
     )
     rb_lib = streamer.rb_lib

--- a/src/daq2lh5/data_streamer.py
+++ b/src/daq2lh5/data_streamer.py
@@ -129,7 +129,6 @@ class DataStreamer(ABC):
 
             # Parse wildcard keys in RawBuffers and replace with known keys of the decoder.
             dec_key_list = sum(decoder.get_key_lists(), [])
-            dec_key_type = type(dec_key_list[0])  # requires consistent types
             dec_key_list = set(map(str, dec_key_list))
 
             log.debug(f"{dec_name} offers keys {dec_key_list}")

--- a/src/daq2lh5/data_streamer.py
+++ b/src/daq2lh5/data_streamer.py
@@ -132,6 +132,8 @@ class DataStreamer(ABC):
             dec_key_type = type(dec_key_list[0]) # requires consistent types
             dec_key_list = set(map(str,dec_key_list))
 
+            log.debug(f"{dec_name} offers keys {dec_key_list}")
+
             # track keys which are already used
             matched_keys = set()
             only_wildcard_rb = None
@@ -170,7 +172,19 @@ class DataStreamer(ABC):
                     log.debug(f"{dec_name} remaining keys: {dec_key_list}")
                     matched_keys |= matches
 
-                rb.key_list = [dec_key_type(_) if _ != 'None' else None for _ in matched_keys]
+                # Construct the new key_list for the RawBuffer
+                # Expect anything that can be cast to int wants to be cast
+                rb.key_list = []
+                for key in matched_keys:
+                    if key == 'None':
+                        rb.key_list.append(None)
+                    try:
+                        new_key = int(key)
+                        rb.key_list.append(new_key)
+                    except ValueError:
+                        rb.key_list.append(key)
+
+
                 if len(rb.key_list) == 0:
                     log.warning(f"no matched keys for key_list {rb.key_list} in {dec_name}.{rb.out_name}")
                 log.debug(f"{dec_name}:{rb.out_stream}/{rb.out_name} matched wildcards to {rb.key_list}")

--- a/src/daq2lh5/data_streamer.py
+++ b/src/daq2lh5/data_streamer.py
@@ -129,8 +129,8 @@ class DataStreamer(ABC):
 
             # Parse wildcard keys in RawBuffers and replace with known keys of the decoder.
             dec_key_list = sum(decoder.get_key_lists(), [])
-            dec_key_type = type(dec_key_list[0]) # requires consistent types
-            dec_key_list = set(map(str,dec_key_list))
+            dec_key_type = type(dec_key_list[0])  # requires consistent types
+            dec_key_list = set(map(str, dec_key_list))
 
             log.debug(f"{dec_name} offers keys {dec_key_list}")
 
@@ -148,7 +148,9 @@ class DataStreamer(ABC):
                         if only_wildcard_rb is None:
                             only_wildcard_rb = rb
                         else:
-                            raise KeyError(f"Only one '*' wildcard key allowed for decoder {dec_name}")
+                            raise KeyError(
+                                f"Only one '*' wildcard key allowed for decoder {dec_name}"
+                            )
 
                     elif "*" in key:
                         wildcard_rbs.append(rb)
@@ -176,7 +178,7 @@ class DataStreamer(ABC):
                 # Expect anything that can be cast to int wants to be cast
                 rb.key_list = []
                 for key in matched_keys:
-                    if key == 'None':
+                    if key == "None":
                         rb.key_list.append(None)
                     try:
                         new_key = int(key)
@@ -184,10 +186,13 @@ class DataStreamer(ABC):
                     except ValueError:
                         rb.key_list.append(key)
 
-
                 if len(rb.key_list) == 0:
-                    log.warning(f"no matched keys for key_list {rb.key_list} in {dec_name}.{rb.out_name}")
-                log.debug(f"{dec_name}:{rb.out_stream}/{rb.out_name} matched wildcards to {rb.key_list}")
+                    log.warning(
+                        f"no matched keys for key_list {rb.key_list} in {dec_name}.{rb.out_name}"
+                    )
+                log.debug(
+                    f"{dec_name}:{rb.out_stream}/{rb.out_name} matched wildcards to {rb.key_list}"
+                )
 
             keyed_name_rbs = []
             ii = 0

--- a/src/daq2lh5/fc/fc_config_decoder.py
+++ b/src/daq2lh5/fc/fc_config_decoder.py
@@ -3,11 +3,10 @@ from __future__ import annotations
 import copy
 import logging
 
-from fcio import FCIO, Limits
 import lgdo
 import numpy as np
+from fcio import FCIO, Limits
 
-from daq2lh5.raw_buffer import RawBufferList
 
 from ..data_decoder import DataDecoder
 

--- a/src/daq2lh5/fc/fc_config_decoder.py
+++ b/src/daq2lh5/fc/fc_config_decoder.py
@@ -14,28 +14,35 @@ from ..data_decoder import DataDecoder
 log = logging.getLogger(__name__)
 
 fc_config_decoded_values = {
-  "packet_id": {
-      "dtype": "uint32",
-      "description": "The index of this decoded packet in the file.",
-  },
-  "nsamples" :  {"dtype": "int32", "description" : "samples per channel"},
-  "nadcs" :  {"dtype": "int32", "description" : "number of adc channels"},
-  "ntriggers" :  {"dtype": "int32", "description" : "number of triggertraces"},
-  "streamid" :  {"dtype": "int32", "description" : "id of stream"},
-  "adcbits" :  {"dtype": "int32", "description" : "bit range of the adc channels"},
-  "sumlength" :  {"dtype": "int32", "description" : "length of the fpga integrator"},
-  "blprecision" :  {"dtype": "int32", "description" : "precision of the fpga baseline"},
-  "mastercards" :  {"dtype": "int32", "description" : "number of attached mastercards"},
-  "triggercards" :  {"dtype": "int32", "description" : "number of attached triggercards"},
-  "adccards" :  {"dtype": "int32", "description" : "number of attached fadccards"},
-  "gps" :  {"dtype": "int32", "description" : "gps mode (0: not used, >0: external pps and 10MHz)"},
-  "tracemap": {
-      "dtype": "uint32",
-      "datatype": "array<1>{array<1>{real}}",
-      "length": Limits.MaxChannels,
-      "description" : ""
-  },
+    "packet_id": {
+        "dtype": "uint32",
+        "description": "The index of this decoded packet in the file.",
+    },
+    "nsamples": {"dtype": "int32", "description": "samples per channel"},
+    "nadcs": {"dtype": "int32", "description": "number of adc channels"},
+    "ntriggers": {"dtype": "int32", "description": "number of triggertraces"},
+    "streamid": {"dtype": "int32", "description": "id of stream"},
+    "adcbits": {"dtype": "int32", "description": "bit range of the adc channels"},
+    "sumlength": {"dtype": "int32", "description": "length of the fpga integrator"},
+    "blprecision": {"dtype": "int32", "description": "precision of the fpga baseline"},
+    "mastercards": {"dtype": "int32", "description": "number of attached mastercards"},
+    "triggercards": {
+        "dtype": "int32",
+        "description": "number of attached triggercards",
+    },
+    "adccards": {"dtype": "int32", "description": "number of attached fadccards"},
+    "gps": {
+        "dtype": "int32",
+        "description": "gps mode (0: not used, >0: external pps and 10MHz)",
+    },
+    "tracemap": {
+        "dtype": "uint32",
+        "datatype": "array<1>{array<1>{real}}",
+        "length": Limits.MaxChannels,
+        "description": "",
+    },
 }
+
 
 class FCConfigDecoder(DataDecoder):
     """Decode FlashCam config data.
@@ -73,19 +80,19 @@ class FCConfigDecoder(DataDecoder):
 
         tbl["packet_id"].nda[loc] = packet_id
 
-        tbl['nsamples'].nda[loc] = fcio.config.eventsamples
-        tbl['nadcs'].nda[loc] = fcio.config.adcs
-        tbl['ntriggers'].nda[loc] = fcio.config.triggers
-        tbl['streamid'].nda[loc] = fcio.config.streamid
-        tbl['adcbits'].nda[loc] = fcio.config.adcbits
-        tbl['sumlength'].nda[loc] = fcio.config.sumlength
-        tbl['blprecision'].nda[loc] = fcio.config.blprecision
-        tbl['mastercards'].nda[loc] = fcio.config.mastercards
-        tbl['triggercards'].nda[loc] = fcio.config.triggercards
-        tbl['adccards'].nda[loc] = fcio.config.adccards
-        tbl['gps'].nda[loc] = fcio.config.gps
+        tbl["nsamples"].nda[loc] = fcio.config.eventsamples
+        tbl["nadcs"].nda[loc] = fcio.config.adcs
+        tbl["ntriggers"].nda[loc] = fcio.config.triggers
+        tbl["streamid"].nda[loc] = fcio.config.streamid
+        tbl["adcbits"].nda[loc] = fcio.config.adcbits
+        tbl["sumlength"].nda[loc] = fcio.config.sumlength
+        tbl["blprecision"].nda[loc] = fcio.config.blprecision
+        tbl["mastercards"].nda[loc] = fcio.config.mastercards
+        tbl["triggercards"].nda[loc] = fcio.config.triggercards
+        tbl["adccards"].nda[loc] = fcio.config.adccards
+        tbl["gps"].nda[loc] = fcio.config.gps
         ntraces = fcio.config.adcs + fcio.config.triggers
-        tbl['tracemap']._set_vector_unsafe(loc, fcio.config.tracemap[:ntraces])
+        tbl["tracemap"]._set_vector_unsafe(loc, fcio.config.tracemap[:ntraces])
 
         config_rb.loc += 1
 
@@ -96,17 +103,17 @@ class FCConfigDecoder(DataDecoder):
         tbl = lgdo.Struct()
 
         fcio_attr_names_map = {
-            "nsamples" : "eventsamples",
-            "nadcs" : "adcs",
-            "ntriggers" : "triggers",
-            "streamid" : "streamid",
-            "adcbits" : "adcbits",
-            "sumlength" : "sumlength",
-            "blprecision" : "blprecision",
-            "mastercards" : "mastercards",
-            "triggercards" : "triggercards",
-            "adccards" : "adccards",
-            "gps" : "gps",
+            "nsamples": "eventsamples",
+            "nadcs": "adcs",
+            "ntriggers": "triggers",
+            "streamid": "streamid",
+            "adcbits": "adcbits",
+            "sumlength": "sumlength",
+            "blprecision": "blprecision",
+            "mastercards": "mastercards",
+            "triggercards": "triggercards",
+            "adccards": "adccards",
+            "gps": "gps",
         }
 
         for name, fcio_attr_name in fcio_attr_names_map.items():

--- a/src/daq2lh5/fc/fc_config_decoder.py
+++ b/src/daq2lh5/fc/fc_config_decoder.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import copy
 import logging
+from typing import Any
 
 import lgdo
 import numpy as np

--- a/src/daq2lh5/fc/fc_config_decoder.py
+++ b/src/daq2lh5/fc/fc_config_decoder.py
@@ -7,7 +7,6 @@ import lgdo
 import numpy as np
 from fcio import FCIO, Limits
 
-
 from ..data_decoder import DataDecoder
 
 log = logging.getLogger(__name__)

--- a/src/daq2lh5/fc/fc_config_decoder.py
+++ b/src/daq2lh5/fc/fc_config_decoder.py
@@ -14,6 +14,10 @@ from ..data_decoder import DataDecoder
 log = logging.getLogger(__name__)
 
 fc_config_decoded_values = {
+  "packet_id": {
+      "dtype": "uint32",
+      "description": "The index of this decoded packet in the file.",
+  },
   "nsamples" :  {"dtype": "int32", "description" : "samples per channel"},
   "nadcs" :  {"dtype": "int32", "description" : "number of adc channels"},
   "ntriggers" :  {"dtype": "int32", "description" : "number of triggertraces"},
@@ -67,6 +71,8 @@ class FCConfigDecoder(DataDecoder):
         tbl = config_rb.lgdo
         loc = config_rb.loc
 
+        tbl["packet_id"].nda[loc] = packet_id
+
         tbl['nsamples'].nda[loc] = fcio.config.eventsamples
         tbl['nadcs'].nda[loc] = fcio.config.adcs
         tbl['ntriggers'].nda[loc] = fcio.config.triggers
@@ -80,6 +86,8 @@ class FCConfigDecoder(DataDecoder):
         tbl['gps'].nda[loc] = fcio.config.gps
         ntraces = fcio.config.adcs + fcio.config.triggers
         tbl['tracemap']._set_vector_unsafe(loc, fcio.config.tracemap[:ntraces])
+
+        config_rb.loc += 1
 
         return config_rb.is_full()
 

--- a/src/daq2lh5/fc/fc_event_decoder.py
+++ b/src/daq2lh5/fc/fc_event_decoder.py
@@ -14,15 +14,13 @@ log = logging.getLogger(__name__)
 
 fc_event_decoded_values = copy.deepcopy(fc_eventheader_decoded_values)
 
-# The event decoding splits all array values into scalars to allow
-# decoding per key
+# The event decoding splits all arrays in the header into scalars to support decoding per key
 for key in [
     "board_id",
     "fc_input",
     "runtime",
     "lifetime",
     "deadtime",
-    "deadtime_nsec",
     "deadinterval_nsec",
     "baseline",
     "daqenergy",
@@ -32,7 +30,6 @@ for key in [
 
 # tracelist contains contains the mapping for array indices to channel indices
 fc_event_decoded_values.pop("tracelist")
-#
 fc_event_decoded_values["channel"] = {
     "dtype": "uint16",
     "description": "The index of each read out channel in this stream.",
@@ -172,6 +169,9 @@ class FCEventDecoder(DataDecoder):
             tbl["dr_stop_pps"].nda[loc] = fcio.event.deadregion[2]
             tbl["dr_stop_ticks"].nda[loc] = fcio.event.deadregion[3]
             tbl["dr_maxticks"].nda[loc] = fcio.event.deadregion[4]
+            # if event_type == 11: provides the same check
+            # however, the usage of deadregion[5]/[6] must never change
+            # and it will always be present if deadregion[7..] is ever used
             if fcio.event.deadregion_size >= 7:
                 tbl["dr_ch_idx"].nda[loc] = fcio.event.deadregion[5]
                 tbl["dr_ch_len"].nda[loc] = fcio.event.deadregion[6]
@@ -183,7 +183,6 @@ class FCEventDecoder(DataDecoder):
             tbl["timestamp"].nda[loc] = fcio.event.unix_time_utc_sec
             tbl["deadinterval_nsec"].nda[loc] = fcio.event.dead_interval_nsec[ii]
             tbl["deadtime"].nda[loc] = fcio.event.dead_time_sec[ii]
-            tbl["deadtime_nsec"].nda[loc] = fcio.event.dead_time_nsec[ii]
             tbl["lifetime"].nda[loc] = fcio.event.life_time_sec[ii]
             tbl["runtime"].nda[loc] = fcio.event.run_time_sec[ii]
             tbl["baseline"].nda[loc] = fcio.event.fpga_baseline[ii]

--- a/src/daq2lh5/fc/fc_event_decoder.py
+++ b/src/daq2lh5/fc/fc_event_decoder.py
@@ -134,7 +134,6 @@ class FCEventDecoder(DataDecoder):
         # a list of channels is read out simultaneously for each event
         for ii, trace_idx in enumerate(fcio.event.trace_list):
             key = self.key_list[trace_idx]
-            log.debug(f"decoding key {key}")
             if key not in evt_rbkd:
                 if key not in self.skipped_channels:
                     # TODO: should this be a warning instead?

--- a/src/daq2lh5/fc/fc_event_decoder.py
+++ b/src/daq2lh5/fc/fc_event_decoder.py
@@ -132,8 +132,10 @@ class FCEventDecoder(DataDecoder):
         any_full = False
 
         # a list of channels is read out simultaneously for each event
-        for ii, trace_idx in enumerate(fcio.event.trace_list):
-            key = self.key_list[trace_idx]
+        for ii, (trace_idx, addr, chan) in enumerate(
+            zip(fcio.event.trace_list, fcio.event.card_address, fcio.event.card_channel)
+        ):
+            key = get_key(fcio.config.streamid, addr, chan)
             if key not in evt_rbkd:
                 if key not in self.skipped_channels:
                     # TODO: should this be a warning instead?

--- a/src/daq2lh5/fc/fc_event_decoder.py
+++ b/src/daq2lh5/fc/fc_event_decoder.py
@@ -4,8 +4,8 @@ import copy
 import logging
 from typing import Any
 
-from fcio import FCIO, Tags, Limits
 import lgdo
+from fcio import FCIO, Limits
 
 from ..data_decoder import DataDecoder
 from .fc_eventheader_decoder import fc_eventheader_decoded_values, get_key

--- a/src/daq2lh5/fc/fc_eventheader_decoder.py
+++ b/src/daq2lh5/fc/fc_eventheader_decoder.py
@@ -206,7 +206,6 @@ class FCEventHeaderDecoder(DataDecoder):
         self.decoded_values["tracelist"]["length_guess"] = n_traces
         self.decoded_values["board_id"]["length_guess"] = n_traces
         self.decoded_values["fc_input"]["length_guess"] = n_traces
-        self.decoded_values["deadtime_nsec"]["length_guess"] = n_traces
         self.decoded_values["deadinterval_nsec"]["length_guess"] = n_traces
         self.decoded_values["deadtime"]["length_guess"] = n_traces
         self.decoded_values["runtime"]["length_guess"] = n_traces
@@ -295,9 +294,6 @@ class FCEventHeaderDecoder(DataDecoder):
 
         tbl["deadtime"].flattened_data.nda[start:end] = fcio.event.dead_time_sec
         tbl["deadtime"].cumulative_length[loc] = end
-
-        tbl["deadtime_nsec"].flattened_data.nda[start:end] = fcio.event.dead_time_nsec
-        tbl["deadtime_nsec"].cumulative_length[loc] = end
 
         tbl["lifetime"].flattened_data.nda[start:end] = fcio.event.life_time_sec
         tbl["lifetime"].cumulative_length[loc] = end

--- a/src/daq2lh5/fc/fc_eventheader_decoder.py
+++ b/src/daq2lh5/fc/fc_eventheader_decoder.py
@@ -7,7 +7,6 @@ from typing import Any
 import lgdo
 from fcio import FCIO, Limits
 
-
 from ..data_decoder import DataDecoder
 
 log = logging.getLogger(__name__)

--- a/src/daq2lh5/fc/fc_eventheader_decoder.py
+++ b/src/daq2lh5/fc/fc_eventheader_decoder.py
@@ -92,13 +92,6 @@ fc_eventheader_decoded_values = {
         "units": "s",
         "description": "The accumulated time for which the hardware buffers were full (dead). Recorded per channel.",
     },
-    "deadtime_nsec": {
-        "dtype": "int64",
-        "datatype": "array<1>{array<1>{real}}",
-        "length_guess": Limits.MaxChannels,
-        "units": "ns",
-        "description": "Same as the deadtime field, but recorded in nanoseconds with 4ns precision (due to the internal clock speed of 250MHz).",
-    },
     "deadinterval_nsec": {
         "dtype": "int64",
         "datatype": "array<1>{array<1>{real}}",

--- a/src/daq2lh5/fc/fc_eventheader_decoder.py
+++ b/src/daq2lh5/fc/fc_eventheader_decoder.py
@@ -154,23 +154,23 @@ fc_eventheader_decoded_values = {
     },
     "dr_start_pps": {
         "dtype": "int32",
-        "description": "The PPS counter value when the hardware buffers were full (dead), before this event. Only changes if a new value is aquired.",
+        "description": "The PPS counter value when the hardware buffers were full (dead), before this event. Only changes if a new value is acquired.",
     },
     "dr_start_ticks": {
         "dtype": "int32",
-        "description": "The ticks counter value when the hardware buffers were full (dead), before this event. Only changes if a new value is aquired.",
+        "description": "The ticks counter value when the hardware buffers were full (dead), before this event. Only changes if a new value is acquired.",
     },
     "dr_stop_pps": {
         "dtype": "int32",
-        "description": "The PPS counter value when the hardware buffers free (life) again, before this event. Only changes if a new value is aquired.",
+        "description": "The PPS counter value when the hardware buffers are free (life) again, before this event. Only changes if a new value is acquired.",
     },
     "dr_stop_ticks": {
         "dtype": "int32",
-        "description": "The ticks counter value when the hardware buffers free (life) again, before this event. Only changes if a new value is aquired.",
+        "description": "The ticks counter value when the hardware buffers are free (life) again, before this event. Only changes if a new value is acquired.",
     },
     "dr_maxticks": {
         "dtype": "int32",
-        "description": "The ticks counter value on PPS when the hardware buffers were freed, before this event. Only changes if a new value is aquired.",
+        "description": "The ticks counter value on PPS when the hardware buffers were freed, before this event. Only changes if a new value is acquired.",
     },
     "dr_ch_idx": {
         "dtype": "uint16",

--- a/src/daq2lh5/fc/fc_eventheader_decoder.py
+++ b/src/daq2lh5/fc/fc_eventheader_decoder.py
@@ -4,16 +4,11 @@ import copy
 import logging
 from typing import Any
 
-from daq2lh5.raw_buffer import RawBuffer, RawBufferList
-from fcio import FCIO, Tags, Limits
 import lgdo
+from fcio import FCIO, Limits
 
-from lgdo.types import vovutils
-import numpy as np
 
 from ..data_decoder import DataDecoder
-
-import line_profiler
 
 log = logging.getLogger(__name__)
 

--- a/src/daq2lh5/fc/fc_eventheader_decoder.py
+++ b/src/daq2lh5/fc/fc_eventheader_decoder.py
@@ -17,6 +17,7 @@ import line_profiler
 
 log = logging.getLogger(__name__)
 
+
 def get_key(streamid: int, card_address: int, card_input: int, iwf: int = -1) -> int:
     if streamid > 0 or iwf < 0:
         # For backwards compatibility only the lower 16-bit of the streamid are

--- a/src/daq2lh5/fc/fc_eventheader_decoder.py
+++ b/src/daq2lh5/fc/fc_eventheader_decoder.py
@@ -214,7 +214,6 @@ class FCEventHeaderDecoder(DataDecoder):
             extracted via :meth:`~.fc_config_decoder.FCConfigDecoder.decode_config`.
         """
         n_traces = len(fcio_stream.config.tracemap)
-        # self.max_rows_in_packet = max(n_traces, self.max_rows_in_packet)
 
         self.decoded_values["tracelist"]["length_guess"] = n_traces
         self.decoded_values["board_id"]["length_guess"] = n_traces
@@ -242,12 +241,16 @@ class FCEventHeaderDecoder(DataDecoder):
     def decode_packet(
         self,
         fcio: FCIO,
-        evt_hdr_rbkd: lgdo.Table | dict[int, lgdo.Table],
+        evt_hdr_rbkd: dict[int, lgdo.Table],
         packet_id: int,
     ) -> bool:
 
         # only one key available: this streamid
-        evt_hdr_rb = evt_hdr_rbkd[self.key_list[0]]
+        key = get_key(fcio.config.streamid, 0, 0)
+        if key not in evt_hdr_rbkd:
+            return False
+
+        evt_hdr_rb = evt_hdr_rbkd[key]
 
         tbl = evt_hdr_rb.lgdo
         loc = evt_hdr_rb.loc

--- a/src/daq2lh5/fc/fc_eventheader_decoder.py
+++ b/src/daq2lh5/fc/fc_eventheader_decoder.py
@@ -1,0 +1,324 @@
+from __future__ import annotations
+
+import copy
+import logging
+from typing import Any
+
+from daq2lh5.raw_buffer import RawBuffer, RawBufferList
+from fcio import FCIO, Tags, Limits
+import lgdo
+
+from lgdo.types import vovutils
+import numpy as np
+
+from ..data_decoder import DataDecoder
+
+import line_profiler
+
+log = logging.getLogger(__name__)
+
+def get_key(streamid: int, card_address: int, card_input: int, iwf: int = -1) -> int:
+    if streamid > 0 or iwf < 0:
+        # For backwards compatibility only the lower 16-bit of the streamid are
+        # used.
+        return (streamid & 0xFFFF) * 1000000 + card_address * 100 + card_input
+    else:
+        return iwf
+
+
+def get_fcid(key: int) -> int:
+    return int(key // 1000000)
+
+
+def get_card_address(key: int) -> int:
+    return int((key // 100) % 10000)
+
+
+def get_card_input(key: int) -> int:
+    return int(key % 100)
+
+
+# put decoded values here where they can be used also by the orca decoder
+fc_eventheader_decoded_values = {
+    "packet_id": {
+        "dtype": "uint32",
+        "description": "The index of this decoded packet in the file.",
+    },
+    "fcid": {"dtype": "uint16", "description": "The ID of this data stream."},
+    "board_id": {
+        "dtype": "uint16",
+        "datatype": "array<1>{array<1>{real}}",
+        "length_guess": Limits.MaxChannels,
+        "description": "The MAC address of the FlashCam board which recorded this event.",
+    },
+    "fc_input": {
+        "dtype": "uint16",
+        "datatype": "array<1>{array<1>{real}}",
+        "length_guess": Limits.MaxChannels,
+        "description": "The per-board ADC channel. Corresponds to the input connector in 62.5MHz mode or the input wire in 250MHz mode.",
+    },
+    "eventnumber": {
+        "dtype": "int32",
+        "description": "Counts triggered events. Fetched from the master board in non-sparse, or from the ADC board in sparse.",
+    },
+    "event_type": {
+        "dtype": "int32",
+        "description": "Is 1 for shared trigger/readout, or 11 in true sparse mode where ADC boards trigger independently.",
+    },
+    "timestamp": {
+        "dtype": "float64",
+        "units": "s",
+        "description": "Time since epoch (unix time) for this event.",
+    },
+    "runtime": {
+        "dtype": "float64",
+        "datatype": "array<1>{array<1>{real}}",
+        "length_guess": Limits.MaxChannels,
+        "units": "s",
+        "description": "Time since trigger enable of this run. Recorded per channel.",
+    },
+    "lifetime": {
+        "dtype": "float64",
+        "datatype": "array<1>{array<1>{real}}",
+        "length_guess": Limits.MaxChannels,
+        "units": "s",
+        "description": "The accumulated lifetime since trigger enable, for which the hardware was not dead. Recorded per channel.",
+    },
+    "deadtime": {
+        "dtype": "float64",
+        "datatype": "array<1>{array<1>{real}}",
+        "length_guess": Limits.MaxChannels,
+        "units": "s",
+        "description": "The accumulated time for which the hardware buffers were full (dead). Recorded per channel.",
+    },
+    "deadtime_nsec": {
+        "dtype": "int64",
+        "datatype": "array<1>{array<1>{real}}",
+        "length_guess": Limits.MaxChannels,
+        "units": "ns",
+        "description": "Same as the deadtime field, but recorded in nanoseconds with 4ns precision (due to the internal clock speed of 250MHz).",
+    },
+    "deadinterval_nsec": {
+        "dtype": "int64",
+        "datatype": "array<1>{array<1>{real}}",
+        "length_guess": Limits.MaxChannels,
+        "units": "ns",
+        "description": "The interval the board was dead between previous event and this event in nanoseconds with 4ns precision (due to the internal clock speed of 250MHz).",
+    },
+    "numtraces": {"dtype": "int32"},
+    "tracelist": {
+        "dtype": "uint16",
+        "datatype": "array<1>{array<1>{real}}",
+        "length_guess": Limits.MaxChannels,
+        "description": "The number of read out adc channels in this event.",
+    },
+    "baseline": {
+        "dtype": "uint16",
+        "datatype": "array<1>{array<1>{real}}",
+        "length_guess": Limits.MaxChannels,
+        "description": "The baseline determined by the FPGA baseline algorithm.",
+    },
+    "daqenergy": {
+        "dtype": "uint16",
+        "datatype": "array<1>{array<1>{real}}",
+        "length_guess": Limits.MaxChannels,
+        "description": "The shaped pulse peak height above the trigger threshold for 62.5MHz mode. The waveform integral over `sumlength` samples in 250MHz mode.",
+    },
+    "ts_pps": {
+        "dtype": "int32",
+        "description": "The pulse-per-second (PPS) counter since DAQ reset.",
+    },
+    "ts_ticks": {
+        "dtype": "int32",
+        "description": "The clock ticks counter (250MHz) since last PPS.",
+    },
+    "ts_maxticks": {
+        "dtype": "int32",
+        "description": "The clock ticks counter value when the last PPS arrived.",
+    },
+    "mu_offset_sec": {
+        "dtype": "int32",
+        "description": "The seconds between server (unix) and fpga time. See `man 2 gettimeofday`.",
+    },
+    "mu_offset_usec": {
+        "dtype": "int32",
+        "description": "The microseconds between server (unix second) and fpga time (pps). See `man 2 gettimeofday`",
+    },
+    "to_master_sec": {
+        "dtype": "int32",
+        "description": "The timeoffset between server (unix) and fpga clocks, only valid when a gps clock/time server is used and the offset to epoch needs to be adjusted.",
+    },
+    "delta_mu_usec": {
+        "dtype": "int32",
+        "description": "The clock offset in microseconds between fpga and server for aligned clocks.",
+    },
+    "abs_delta_mu_usec": {
+        "dtype": "int32",
+        "description": "The absolute value of `delta_mu_usec`.",
+    },
+    "to_start_sec": {
+        "dtype": "int32",
+        "description": "The seconds of the start time of the run / trigger enable.",
+    },
+    "to_start_usec": {
+        "dtype": "int32",
+        "description": "The microseconds of the start time of the run / trigger enable.",
+    },
+    "dr_start_pps": {
+        "dtype": "int32",
+        "description": "The PPS counter value when the hardware buffers were full (dead), before this event. Only changes if a new value is aquired.",
+    },
+    "dr_start_ticks": {
+        "dtype": "int32",
+        "description": "The ticks counter value when the hardware buffers were full (dead), before this event. Only changes if a new value is aquired.",
+    },
+    "dr_stop_pps": {
+        "dtype": "int32",
+        "description": "The PPS counter value when the hardware buffers free (life) again, before this event. Only changes if a new value is aquired.",
+    },
+    "dr_stop_ticks": {
+        "dtype": "int32",
+        "description": "The ticks counter value when the hardware buffers free (life) again, before this event. Only changes if a new value is aquired.",
+    },
+    "dr_maxticks": {
+        "dtype": "int32",
+        "description": "The ticks counter value on PPS when the hardware buffers were freed, before this event. Only changes if a new value is aquired.",
+    },
+    "dr_ch_idx": {
+        "dtype": "uint16",
+        "description": "The start channel index of channels which are affected by the recorded dead interval.",
+    },
+    "dr_ch_len": {
+        "dtype": "uint16",
+        "description": "The number of channels which are affected by the dead interval, starts from `dr_ch_idx`. Can be larger than `num_traces`.",
+    },
+}
+
+
+class FCEventHeaderDecoder(DataDecoder):
+    def __init__(self, *args, **kwargs) -> None:
+        self.decoded_values = copy.deepcopy(fc_eventheader_decoded_values)
+        super().__init__(*args, **kwargs)
+        self.max_rows_in_packet = (
+            1  # only == 1 if len(array) in table is counted as one.
+        )
+        self.key_list = []
+
+    def set_fcio_stream(self, fcio_stream: FCIO) -> None:
+        """Access ``FCIOConfig`` members once when each file is opened.
+
+        Parameters
+        ----------
+        fc_config
+            extracted via :meth:`~.fc_config_decoder.FCConfigDecoder.decode_config`.
+        """
+        n_traces = len(fcio_stream.config.tracemap)
+        # self.max_rows_in_packet = max(n_traces, self.max_rows_in_packet)
+
+        self.decoded_values["tracelist"]["length_guess"] = n_traces
+        self.decoded_values["board_id"]["length_guess"] = n_traces
+        self.decoded_values["fc_input"]["length_guess"] = n_traces
+        self.decoded_values["deadtime_nsec"]["length_guess"] = n_traces
+        self.decoded_values["deadinterval_nsec"]["length_guess"] = n_traces
+        self.decoded_values["deadtime"]["length_guess"] = n_traces
+        self.decoded_values["runtime"]["length_guess"] = n_traces
+        self.decoded_values["lifetime"]["length_guess"] = n_traces
+        self.decoded_values["baseline"]["length_guess"] = n_traces
+        self.decoded_values["daqenergy"]["length_guess"] = n_traces
+
+        self.key_list = [get_key(fcio_stream.config.streamid, 0, 0)]
+
+    def get_key_lists(self) -> list[list[int | str]]:
+        return [copy.deepcopy(self.key_list)]
+
+    def get_decoded_values(self, key: int | str = None) -> dict[str, dict[str, Any]]:
+        # FC uses the same values for all channels
+        return self.decoded_values
+
+    def get_max_rows_in_packet(self) -> int:
+        return self.max_rows_in_packet
+
+    def decode_packet(
+        self,
+        fcio: FCIO,
+        evt_hdr_rbkd: lgdo.Table | dict[int, lgdo.Table],
+        packet_id: int,
+    ) -> bool:
+
+        # only one key available: this streamid
+        evt_hdr_rb = evt_hdr_rbkd[self.key_list[0]]
+
+        tbl = evt_hdr_rb.lgdo
+        loc = evt_hdr_rb.loc
+
+        tbl["packet_id"].nda[loc] = packet_id
+        tbl["fcid"].nda[loc] = fcio.config.streamid & 0xFFFF
+        tbl["event_type"].nda[loc] = fcio.event.type
+        tbl["eventnumber"].nda[loc] = fcio.event.timestamp[0]
+        tbl["ts_pps"].nda[loc] = fcio.event.timestamp[1]
+        tbl["ts_ticks"].nda[loc] = fcio.event.timestamp[2]
+        tbl["ts_maxticks"].nda[loc] = fcio.event.timestamp[3]
+        tbl["mu_offset_sec"].nda[loc] = fcio.event.timeoffset[0]
+        tbl["mu_offset_usec"].nda[loc] = fcio.event.timeoffset[1]
+        tbl["to_master_sec"].nda[loc] = fcio.event.timeoffset[2]
+        tbl["delta_mu_usec"].nda[loc] = fcio.event.timeoffset[3]
+        tbl["abs_delta_mu_usec"].nda[loc] = fcio.event.timeoffset[4]
+        tbl["to_start_sec"].nda[loc] = fcio.event.timeoffset[5]
+        tbl["to_start_usec"].nda[loc] = fcio.event.timeoffset[6]
+        tbl["dr_start_pps"].nda[loc] = fcio.event.deadregion[0]
+        tbl["dr_start_ticks"].nda[loc] = fcio.event.deadregion[1]
+        tbl["dr_stop_pps"].nda[loc] = fcio.event.deadregion[2]
+        tbl["dr_stop_ticks"].nda[loc] = fcio.event.deadregion[3]
+        tbl["dr_maxticks"].nda[loc] = fcio.event.deadregion[4]
+        # the dead-time affected channels
+        if fcio.event.deadregion_size >= 7:
+            tbl["dr_ch_idx"].nda[loc] = fcio.event.deadregion[5]
+            tbl["dr_ch_len"].nda[loc] = fcio.event.deadregion[6]
+        else:
+            tbl["dr_ch_idx"].nda[loc] = 0
+            tbl["dr_ch_len"].nda[loc] = fcio.config.adcs
+
+        # The following values are derived values by fcio-py
+        # the time since epoch in seconds
+        tbl["timestamp"].nda[loc] = fcio.event.unix_time_utc_sec
+
+        tbl["numtraces"].nda[loc] = fcio.event.num_traces
+
+        start = 0 if loc == 0 else tbl["tracelist"].cumulative_length[loc - 1]
+        end = start + fcio.event.num_traces
+
+        tbl["tracelist"].flattened_data.nda[start:end] = fcio.event.trace_list
+        tbl["tracelist"].cumulative_length[loc] = end
+
+        tbl["board_id"].flattened_data.nda[start:end] = fcio.event.card_address
+        tbl["board_id"].cumulative_length[loc] = end
+
+        tbl["fc_input"].flattened_data.nda[start:end] = fcio.event.card_channel
+        tbl["fc_input"].cumulative_length[loc] = end
+
+        tbl["deadinterval_nsec"].flattened_data.nda[
+            start:end
+        ] = fcio.event.dead_interval_nsec
+        tbl["deadinterval_nsec"].cumulative_length[loc] = end
+
+        tbl["deadtime"].flattened_data.nda[start:end] = fcio.event.dead_time_sec
+        tbl["deadtime"].cumulative_length[loc] = end
+
+        tbl["deadtime_nsec"].flattened_data.nda[start:end] = fcio.event.dead_time_nsec
+        tbl["deadtime_nsec"].cumulative_length[loc] = end
+
+        tbl["lifetime"].flattened_data.nda[start:end] = fcio.event.life_time_sec
+        tbl["lifetime"].cumulative_length[loc] = end
+
+        tbl["runtime"].flattened_data.nda[start:end] = fcio.event.run_time_sec
+        tbl["runtime"].cumulative_length[loc] = end
+
+        tbl["baseline"].flattened_data.nda[start:end] = fcio.event.fpga_baseline
+        tbl["baseline"].cumulative_length[loc] = end
+
+        tbl["daqenergy"].flattened_data.nda[start:end] = fcio.event.fpga_energy
+        tbl["daqenergy"].cumulative_length[loc] = end
+
+        evt_hdr_rb.loc += 1
+
+        return evt_hdr_rb.is_full()

--- a/src/daq2lh5/fc/fc_fsp_decoder.py
+++ b/src/daq2lh5/fc/fc_fsp_decoder.py
@@ -18,52 +18,152 @@ fsp_config_decoded_values = {
         "dtype": "uint32",
         "description": "The index of this decoded packet in the file.",
     },
-    "buffer_max_states" : { 'dtype' : 'int32', 'description' : ""},
-    "buffer_window_nsec" : { 'dtype' : 'int64', 'description' : ""},
-    "trg_hwm_min_multiplicity" : { 'dtype' : 'int32', 'description' : ""},
-    "trg_hwm_prescale_ratio" : { 'dtype' : 'int32', 'description' : ""},
-    "trg_wps_prescale_ratio" : { 'dtype' : 'int32', 'description' : ""},
-    "trg_wps_coincident_sum_threshold" : { 'dtype' : 'float32', 'description' : ""},
-    "trg_wps_sum_threshold" : { 'dtype' : 'float32', 'description' : ""},
-    "trg_wps_prescale_rate" : { 'dtype' : 'float32', 'description' : ""},
-    "trg_hwm_prescale_rate" : { 'dtype' : 'float32', 'description' : ""},
-    "trg_wps_ref_flags_hwm" : { 'dtype' : 'int64', 'description' : ""},
-    "trg_wps_ref_flags_ct" : { 'dtype' : 'int64', 'description' : ""},
-    "trg_wps_ref_flags_wps" : { 'dtype' : 'int64', 'description' : ""},
-    "trg_wps_ref_map_idx" : { 'dtype' : 'int32', "datatype": "array<1>{array<1>{real}}", "length_guess": Limits.MaxChannels, 'description' : ""},
-    "trg_enabled_write_flags_trigger" : { 'dtype' : 'int64', 'description' : ""},
-    "trg_enabled_write_flags_event" : { 'dtype' : 'int64', 'description' : ""},
-    "trg_pre_trigger_window_nsec" : { 'dtype' : 'int64', 'description' : ""},
-    "trg_post_trigger_window_nsec" : { 'dtype' : 'int64', 'description' : ""},
-    "dsp_wps_tracemap_format" : { 'dtype' : 'int32', 'description' : ""},
-    "dsp_wps_tracemap_indices" : { 'dtype' : 'int32', "datatype": "array<1>{array<1>{real}}", "length_guess": Limits.MaxChannels, 'description' : ""},
-    "dsp_wps_tracemap_enabled" : { 'dtype' : 'int32', "datatype": "array<1>{array<1>{real}}", "length_guess": Limits.MaxChannels, 'description' : ""},
-    "dsp_wps_tracemap_label" : { 'dtype' : '|S7', "datatype": "array_of_equalsized_arrays<1,1>{string}", "length": Limits.MaxChannels, 'description' : ""},
-    "dsp_wps_gains" : { 'dtype' : 'float32', "datatype": "array<1>{array<1>{real}}", "length_guess": Limits.MaxChannels, 'description' : ""},
-    "dsp_wps_thresholds" : { 'dtype' : 'float32', "datatype": "array<1>{array<1>{real}}", "length_guess": Limits.MaxChannels, 'description' : ""},
-    "dsp_wps_lowpass" : { 'dtype' : 'float32', "datatype": "array<1>{array<1>{real}}", "length_guess": Limits.MaxChannels, 'description' : ""},
-    "dsp_wps_shaping_widths" : { 'dtype' : 'int32', "datatype": "array<1>{array<1>{real}}", "length_guess": Limits.MaxChannels, 'description' : ""},
-    "dsp_wps_margin_front" : { 'dtype' : 'int32', "datatype": "array<1>{array<1>{real}}", "length_guess": Limits.MaxChannels, 'description' : ""},
-    "dsp_wps_margin_back" : { 'dtype' : 'int32', "datatype": "array<1>{array<1>{real}}", "length_guess": Limits.MaxChannels, 'description' : ""},
-    "dsp_wps_start_sample" : { 'dtype' : 'int32', "datatype": "array<1>{array<1>{real}}", "length_guess": Limits.MaxChannels, 'description' : ""},
-    "dsp_wps_stop_sample" : { 'dtype' : 'int32', "datatype": "array<1>{array<1>{real}}", "length_guess": Limits.MaxChannels, 'description' : ""},
-    "dsp_wps_dsp_max_margin_front" : { 'dtype' : 'int32', 'description' : ""},
-    "dsp_wps_dsp_max_margin_back" : { 'dtype' : 'int32', 'description' : ""},
-    "dsp_wps_apply_gain_scaling" : { 'dtype' : 'int32', 'description' : ""},
-    "dsp_wps_sum_window_size" : { 'dtype' : 'int32', 'description' : ""},
-    "dsp_wps_sum_window_start_sample" : { 'dtype' : 'int32', 'description' : ""},
-    "dsp_wps_sum_window_stop_sample" : { 'dtype' : 'int32', 'description' : ""},
-    "dsp_wps_sub_event_sum_threshold" : { 'dtype' : 'float32', 'description' : ""},
-    "dsp_hwm_tracemap_format" : { 'dtype' : 'int32', 'description' : ""},
-    "dsp_hwm_tracemap_indices" : { 'dtype' : 'int32', "datatype": "array<1>{array<1>{real}}", "length_guess": Limits.MaxChannels, 'description' : ""},
-    "dsp_hwm_tracemap_enabled" : { 'dtype' : 'int32', "datatype": "array<1>{array<1>{real}}", "length_guess": Limits.MaxChannels, 'description' : ""},
-    "dsp_hwm_tracemap_label" : { 'dtype' : '|S7', "datatype": "array_of_equalsized_arrays<1,1>{string}", "length": Limits.MaxChannels, 'description' : ""},
-    "dsp_hwm_fpga_energy_threshold_adc" : { 'dtype' : 'uint16', "datatype": "array<1>{array<1>{real}}", "length_guess": Limits.MaxChannels, 'description' : ""},
-    "dsp_ct_tracemap_format" : { 'dtype' : 'int32', 'description' : ""},
-    "dsp_ct_tracemap_indices" : { 'dtype' : 'int32', "datatype": "array<1>{array<1>{real}}", "length_guess": Limits.MaxChannels, 'description' : ""},
-    "dsp_ct_tracemap_enabled" : { 'dtype' : 'int32', "datatype": "array<1>{array<1>{real}}", "length_guess": Limits.MaxChannels, 'description' : ""},
-    "dsp_ct_tracemap_label" : { 'dtype' : '|S7', "datatype": "array_of_equalsized_arrays<1,1>{string}", "length": Limits.MaxChannels, 'description' : ""},
-    "dsp_ct_thresholds" : { 'dtype' : 'uint16', "datatype": "array<1>{array<1>{real}}", "length_guess": Limits.MaxChannels, 'description' : ""},
+    "buffer_max_states": {"dtype": "int32", "description": ""},
+    "buffer_window_nsec": {"dtype": "int64", "description": ""},
+    "trg_hwm_min_multiplicity": {"dtype": "int32", "description": ""},
+    "trg_hwm_prescale_ratio": {"dtype": "int32", "description": ""},
+    "trg_wps_prescale_ratio": {"dtype": "int32", "description": ""},
+    "trg_wps_coincident_sum_threshold": {"dtype": "float32", "description": ""},
+    "trg_wps_sum_threshold": {"dtype": "float32", "description": ""},
+    "trg_wps_prescale_rate": {"dtype": "float32", "description": ""},
+    "trg_hwm_prescale_rate": {"dtype": "float32", "description": ""},
+    "trg_wps_ref_flags_hwm": {"dtype": "int64", "description": ""},
+    "trg_wps_ref_flags_ct": {"dtype": "int64", "description": ""},
+    "trg_wps_ref_flags_wps": {"dtype": "int64", "description": ""},
+    "trg_wps_ref_map_idx": {
+        "dtype": "int32",
+        "datatype": "array<1>{array<1>{real}}",
+        "length_guess": Limits.MaxChannels,
+        "description": "",
+    },
+    "trg_enabled_write_flags_trigger": {"dtype": "int64", "description": ""},
+    "trg_enabled_write_flags_event": {"dtype": "int64", "description": ""},
+    "trg_pre_trigger_window_nsec": {"dtype": "int64", "description": ""},
+    "trg_post_trigger_window_nsec": {"dtype": "int64", "description": ""},
+    "dsp_wps_tracemap_format": {"dtype": "int32", "description": ""},
+    "dsp_wps_tracemap_indices": {
+        "dtype": "int32",
+        "datatype": "array<1>{array<1>{real}}",
+        "length_guess": Limits.MaxChannels,
+        "description": "",
+    },
+    "dsp_wps_tracemap_enabled": {
+        "dtype": "int32",
+        "datatype": "array<1>{array<1>{real}}",
+        "length_guess": Limits.MaxChannels,
+        "description": "",
+    },
+    "dsp_wps_tracemap_label": {
+        "dtype": "|S7",
+        "datatype": "array_of_equalsized_arrays<1,1>{string}",
+        "length": Limits.MaxChannels,
+        "description": "",
+    },
+    "dsp_wps_gains": {
+        "dtype": "float32",
+        "datatype": "array<1>{array<1>{real}}",
+        "length_guess": Limits.MaxChannels,
+        "description": "",
+    },
+    "dsp_wps_thresholds": {
+        "dtype": "float32",
+        "datatype": "array<1>{array<1>{real}}",
+        "length_guess": Limits.MaxChannels,
+        "description": "",
+    },
+    "dsp_wps_lowpass": {
+        "dtype": "float32",
+        "datatype": "array<1>{array<1>{real}}",
+        "length_guess": Limits.MaxChannels,
+        "description": "",
+    },
+    "dsp_wps_shaping_widths": {
+        "dtype": "int32",
+        "datatype": "array<1>{array<1>{real}}",
+        "length_guess": Limits.MaxChannels,
+        "description": "",
+    },
+    "dsp_wps_margin_front": {
+        "dtype": "int32",
+        "datatype": "array<1>{array<1>{real}}",
+        "length_guess": Limits.MaxChannels,
+        "description": "",
+    },
+    "dsp_wps_margin_back": {
+        "dtype": "int32",
+        "datatype": "array<1>{array<1>{real}}",
+        "length_guess": Limits.MaxChannels,
+        "description": "",
+    },
+    "dsp_wps_start_sample": {
+        "dtype": "int32",
+        "datatype": "array<1>{array<1>{real}}",
+        "length_guess": Limits.MaxChannels,
+        "description": "",
+    },
+    "dsp_wps_stop_sample": {
+        "dtype": "int32",
+        "datatype": "array<1>{array<1>{real}}",
+        "length_guess": Limits.MaxChannels,
+        "description": "",
+    },
+    "dsp_wps_dsp_max_margin_front": {"dtype": "int32", "description": ""},
+    "dsp_wps_dsp_max_margin_back": {"dtype": "int32", "description": ""},
+    "dsp_wps_apply_gain_scaling": {"dtype": "int32", "description": ""},
+    "dsp_wps_sum_window_size": {"dtype": "int32", "description": ""},
+    "dsp_wps_sum_window_start_sample": {"dtype": "int32", "description": ""},
+    "dsp_wps_sum_window_stop_sample": {"dtype": "int32", "description": ""},
+    "dsp_wps_sub_event_sum_threshold": {"dtype": "float32", "description": ""},
+    "dsp_hwm_tracemap_format": {"dtype": "int32", "description": ""},
+    "dsp_hwm_tracemap_indices": {
+        "dtype": "int32",
+        "datatype": "array<1>{array<1>{real}}",
+        "length_guess": Limits.MaxChannels,
+        "description": "",
+    },
+    "dsp_hwm_tracemap_enabled": {
+        "dtype": "int32",
+        "datatype": "array<1>{array<1>{real}}",
+        "length_guess": Limits.MaxChannels,
+        "description": "",
+    },
+    "dsp_hwm_tracemap_label": {
+        "dtype": "|S7",
+        "datatype": "array_of_equalsized_arrays<1,1>{string}",
+        "length": Limits.MaxChannels,
+        "description": "",
+    },
+    "dsp_hwm_fpga_energy_threshold_adc": {
+        "dtype": "uint16",
+        "datatype": "array<1>{array<1>{real}}",
+        "length_guess": Limits.MaxChannels,
+        "description": "",
+    },
+    "dsp_ct_tracemap_format": {"dtype": "int32", "description": ""},
+    "dsp_ct_tracemap_indices": {
+        "dtype": "int32",
+        "datatype": "array<1>{array<1>{real}}",
+        "length_guess": Limits.MaxChannels,
+        "description": "",
+    },
+    "dsp_ct_tracemap_enabled": {
+        "dtype": "int32",
+        "datatype": "array<1>{array<1>{real}}",
+        "length_guess": Limits.MaxChannels,
+        "description": "",
+    },
+    "dsp_ct_tracemap_label": {
+        "dtype": "|S7",
+        "datatype": "array_of_equalsized_arrays<1,1>{string}",
+        "length": Limits.MaxChannels,
+        "description": "",
+    },
+    "dsp_ct_thresholds": {
+        "dtype": "uint16",
+        "datatype": "array<1>{array<1>{real}}",
+        "length_guess": Limits.MaxChannels,
+        "description": "",
+    },
 }
 
 
@@ -81,27 +181,41 @@ class FSPConfigDecoder(DataDecoder):
             wps_n_traces = fcio_stream.fsp.config.wps["tracemap"]["n_mapped"]
             hwm_n_traces = fcio_stream.fsp.config.hwm["tracemap"]["n_mapped"]
             ct_n_traces = fcio_stream.fsp.config.ct["tracemap"]["n_mapped"]
-            self.decoded_values['dsp_wps_tracemap_label']['length'] = wps_n_traces
-            self.decoded_values['dsp_hwm_tracemap_label']['length'] = hwm_n_traces
-            self.decoded_values['dsp_ct_tracemap_label']['length'] = ct_n_traces
+            self.decoded_values["dsp_wps_tracemap_label"]["length"] = wps_n_traces
+            self.decoded_values["dsp_hwm_tracemap_label"]["length"] = hwm_n_traces
+            self.decoded_values["dsp_ct_tracemap_label"]["length"] = ct_n_traces
 
-            self.decoded_values['trg_wps_ref_map_idx']['length_guess'] = fcio_stream.fsp.config.triggerconfig["n_wps_ref_map_idx"]
-            self.decoded_values['dsp_wps_tracemap_indices']['length_guess'] = wps_n_traces
-            self.decoded_values['dsp_wps_tracemap_enabled']['length_guess'] = fcio_stream.fsp.config.wps["tracemap"]["n_enabled"]
-            self.decoded_values['dsp_wps_gains']['length_guess'] = wps_n_traces
-            self.decoded_values['dsp_wps_thresholds']['length_guess'] = wps_n_traces
-            self.decoded_values['dsp_wps_lowpass']['length_guess'] = wps_n_traces
-            self.decoded_values['dsp_wps_shaping_widths']['length_guess'] = wps_n_traces
-            self.decoded_values['dsp_wps_margin_front']['length_guess'] = wps_n_traces
-            self.decoded_values['dsp_wps_margin_back']['length_guess'] = wps_n_traces
-            self.decoded_values['dsp_wps_start_sample']['length_guess'] = wps_n_traces
-            self.decoded_values['dsp_wps_stop_sample']['length_guess'] = wps_n_traces
-            self.decoded_values['dsp_hwm_tracemap_indices']['length_guess'] = hwm_n_traces
-            self.decoded_values['dsp_hwm_tracemap_enabled']['length_guess'] = fcio_stream.fsp.config.hwm["tracemap"]["n_enabled"]
-            self.decoded_values['dsp_hwm_fpga_energy_threshold_adc']['length_guess'] = hwm_n_traces
-            self.decoded_values['dsp_ct_tracemap_indices']['length_guess'] = ct_n_traces
-            self.decoded_values['dsp_ct_tracemap_enabled']['length_guess'] = fcio_stream.fsp.config.ct["tracemap"]["n_enabled"]
-            self.decoded_values['dsp_ct_thresholds']['length_guess'] = ct_n_traces
+            self.decoded_values["trg_wps_ref_map_idx"]["length_guess"] = (
+                fcio_stream.fsp.config.triggerconfig["n_wps_ref_map_idx"]
+            )
+            self.decoded_values["dsp_wps_tracemap_indices"][
+                "length_guess"
+            ] = wps_n_traces
+            self.decoded_values["dsp_wps_tracemap_enabled"]["length_guess"] = (
+                fcio_stream.fsp.config.wps["tracemap"]["n_enabled"]
+            )
+            self.decoded_values["dsp_wps_gains"]["length_guess"] = wps_n_traces
+            self.decoded_values["dsp_wps_thresholds"]["length_guess"] = wps_n_traces
+            self.decoded_values["dsp_wps_lowpass"]["length_guess"] = wps_n_traces
+            self.decoded_values["dsp_wps_shaping_widths"]["length_guess"] = wps_n_traces
+            self.decoded_values["dsp_wps_margin_front"]["length_guess"] = wps_n_traces
+            self.decoded_values["dsp_wps_margin_back"]["length_guess"] = wps_n_traces
+            self.decoded_values["dsp_wps_start_sample"]["length_guess"] = wps_n_traces
+            self.decoded_values["dsp_wps_stop_sample"]["length_guess"] = wps_n_traces
+            self.decoded_values["dsp_hwm_tracemap_indices"][
+                "length_guess"
+            ] = hwm_n_traces
+            self.decoded_values["dsp_hwm_tracemap_enabled"]["length_guess"] = (
+                fcio_stream.fsp.config.hwm["tracemap"]["n_enabled"]
+            )
+            self.decoded_values["dsp_hwm_fpga_energy_threshold_adc"][
+                "length_guess"
+            ] = hwm_n_traces
+            self.decoded_values["dsp_ct_tracemap_indices"]["length_guess"] = ct_n_traces
+            self.decoded_values["dsp_ct_tracemap_enabled"]["length_guess"] = (
+                fcio_stream.fsp.config.ct["tracemap"]["n_enabled"]
+            )
+            self.decoded_values["dsp_ct_thresholds"]["length_guess"] = ct_n_traces
 
     def get_decoded_values(self, key: int = None) -> dict[str, dict[str, Any]]:
         return self.decoded_values
@@ -137,23 +251,47 @@ class FSPConfigDecoder(DataDecoder):
             buffer["buffer_window"]["seconds"] * 1e9
             + buffer["buffer_window"]["nanoseconds"]
         )
-        tbl["trg_hwm_min_multiplicity"].nda[loc] = np.int32(triggerconfig["hwm_min_multiplicity"])
-        tbl["trg_hwm_prescale_ratio"].nda[loc] = np.int32(triggerconfig["hwm_prescale_ratio"])
-        tbl["trg_wps_prescale_ratio"].nda[loc] = np.int32(triggerconfig["wps_prescale_ratio"])
-        tbl["trg_wps_coincident_sum_threshold"].nda[loc] = np.float32(triggerconfig["wps_coincident_sum_threshold"])
-        tbl["trg_wps_sum_threshold"].nda[loc] = np.float32(triggerconfig["wps_sum_threshold"])
-        tbl["trg_wps_prescale_rate"].nda[loc] = np.float32(triggerconfig["wps_prescale_rate"])
-        tbl["trg_hwm_prescale_rate"].nda[loc] = np.float32(triggerconfig["hwm_prescale_rate"])
-        tbl["trg_wps_ref_flags_hwm"].nda[loc] = np.int64(triggerconfig["wps_ref_flags_hwm"]["is_flagged"])
-        tbl["trg_wps_ref_flags_ct"].nda[loc] = np.int64(triggerconfig["wps_ref_flags_ct"]["is_flagged"])
-        tbl["trg_wps_ref_flags_wps"].nda[loc] = np.int64(triggerconfig["wps_ref_flags_wps"]["is_flagged"])
+        tbl["trg_hwm_min_multiplicity"].nda[loc] = np.int32(
+            triggerconfig["hwm_min_multiplicity"]
+        )
+        tbl["trg_hwm_prescale_ratio"].nda[loc] = np.int32(
+            triggerconfig["hwm_prescale_ratio"]
+        )
+        tbl["trg_wps_prescale_ratio"].nda[loc] = np.int32(
+            triggerconfig["wps_prescale_ratio"]
+        )
+        tbl["trg_wps_coincident_sum_threshold"].nda[loc] = np.float32(
+            triggerconfig["wps_coincident_sum_threshold"]
+        )
+        tbl["trg_wps_sum_threshold"].nda[loc] = np.float32(
+            triggerconfig["wps_sum_threshold"]
+        )
+        tbl["trg_wps_prescale_rate"].nda[loc] = np.float32(
+            triggerconfig["wps_prescale_rate"]
+        )
+        tbl["trg_hwm_prescale_rate"].nda[loc] = np.float32(
+            triggerconfig["hwm_prescale_rate"]
+        )
+        tbl["trg_wps_ref_flags_hwm"].nda[loc] = np.int64(
+            triggerconfig["wps_ref_flags_hwm"]["is_flagged"]
+        )
+        tbl["trg_wps_ref_flags_ct"].nda[loc] = np.int64(
+            triggerconfig["wps_ref_flags_ct"]["is_flagged"]
+        )
+        tbl["trg_wps_ref_flags_wps"].nda[loc] = np.int64(
+            triggerconfig["wps_ref_flags_wps"]["is_flagged"]
+        )
         wps_ref_map_idx = np.array(triggerconfig["wps_ref_map_idx"], dtype="int32")[
             : triggerconfig["n_wps_ref_map_idx"]
         ]
         tbl["trg_wps_ref_map_idx"]._set_vector_unsafe(loc, wps_ref_map_idx)
 
-        tbl["trg_enabled_write_flags_trigger"].nda[loc] = np.int64(triggerconfig["enabled_flags"]["trigger"]["is_flagged"])
-        tbl["trg_enabled_write_flags_event"].nda[loc] = np.int64(triggerconfig["enabled_flags"]["event"]["is_flagged"])
+        tbl["trg_enabled_write_flags_trigger"].nda[loc] = np.int64(
+            triggerconfig["enabled_flags"]["trigger"]["is_flagged"]
+        )
+        tbl["trg_enabled_write_flags_event"].nda[loc] = np.int64(
+            triggerconfig["enabled_flags"]["event"]["is_flagged"]
+        )
         tbl["trg_pre_trigger_window_nsec"].nda[loc] = np.int64(
             triggerconfig["pre_trigger_window"]["seconds"] * 1e9
             + triggerconfig["pre_trigger_window"]["nanoseconds"]
@@ -163,48 +301,98 @@ class FSPConfigDecoder(DataDecoder):
             + triggerconfig["post_trigger_window"]["nanoseconds"]
         )
         tbl["dsp_wps_tracemap_format"].nda[loc] = np.int32(wps["tracemap"]["format"])
-        tbl["dsp_wps_tracemap_indices"]._set_vector_unsafe(loc, np.array(wps["tracemap"]["map"], dtype="int32")[:wps_n_traces])
-        tbl["dsp_wps_tracemap_enabled"]._set_vector_unsafe(loc, np.array(wps["tracemap"]["enabled"], dtype="int32")[
-            : wps["tracemap"]["n_enabled"]
-        ])
+        tbl["dsp_wps_tracemap_indices"]._set_vector_unsafe(
+            loc, np.array(wps["tracemap"]["map"], dtype="int32")[:wps_n_traces]
+        )
+        tbl["dsp_wps_tracemap_enabled"]._set_vector_unsafe(
+            loc,
+            np.array(wps["tracemap"]["enabled"], dtype="int32")[
+                : wps["tracemap"]["n_enabled"]
+            ],
+        )
 
-        tbl["dsp_wps_tracemap_label"].nda[loc][:] = np.array(wps["tracemap"]["label"], dtype="|S7")
+        tbl["dsp_wps_tracemap_label"].nda[loc][:] = np.array(
+            wps["tracemap"]["label"], dtype="|S7"
+        )
 
-        tbl["dsp_wps_gains"]._set_vector_unsafe(loc,np.array(wps["gains"], dtype="float32")[:wps_n_traces])
-        tbl["dsp_wps_thresholds"]._set_vector_unsafe(loc,np.array(wps["thresholds"], dtype="float32")[:wps_n_traces])
-        tbl["dsp_wps_lowpass"]._set_vector_unsafe(loc,np.array(wps["lowpass"], dtype="float32")[:wps_n_traces])
-        tbl["dsp_wps_shaping_widths"]._set_vector_unsafe(loc,np.array(wps["shaping_widths"], dtype="int32")[:wps_n_traces])
-        tbl["dsp_wps_margin_front"]._set_vector_unsafe(loc,np.array(wps["dsp_margin_front"], dtype="int32")[:wps_n_traces])
-        tbl["dsp_wps_margin_back"]._set_vector_unsafe(loc,np.array(wps["dsp_margin_back"], dtype="int32")[:wps_n_traces])
-        tbl["dsp_wps_start_sample"]._set_vector_unsafe(loc,np.array(wps["dsp_start_sample"], dtype="int32")[:wps_n_traces])
-        tbl["dsp_wps_stop_sample"]._set_vector_unsafe(loc,np.array(wps["dsp_stop_sample"], dtype="int32")[:wps_n_traces])
-        tbl["dsp_wps_dsp_max_margin_front"].nda[loc] = np.int32(wps["dsp_max_margin_front"])
-        tbl["dsp_wps_dsp_max_margin_back"].nda[loc] = np.int32(wps["dsp_max_margin_back"])
+        tbl["dsp_wps_gains"]._set_vector_unsafe(
+            loc, np.array(wps["gains"], dtype="float32")[:wps_n_traces]
+        )
+        tbl["dsp_wps_thresholds"]._set_vector_unsafe(
+            loc, np.array(wps["thresholds"], dtype="float32")[:wps_n_traces]
+        )
+        tbl["dsp_wps_lowpass"]._set_vector_unsafe(
+            loc, np.array(wps["lowpass"], dtype="float32")[:wps_n_traces]
+        )
+        tbl["dsp_wps_shaping_widths"]._set_vector_unsafe(
+            loc, np.array(wps["shaping_widths"], dtype="int32")[:wps_n_traces]
+        )
+        tbl["dsp_wps_margin_front"]._set_vector_unsafe(
+            loc, np.array(wps["dsp_margin_front"], dtype="int32")[:wps_n_traces]
+        )
+        tbl["dsp_wps_margin_back"]._set_vector_unsafe(
+            loc, np.array(wps["dsp_margin_back"], dtype="int32")[:wps_n_traces]
+        )
+        tbl["dsp_wps_start_sample"]._set_vector_unsafe(
+            loc, np.array(wps["dsp_start_sample"], dtype="int32")[:wps_n_traces]
+        )
+        tbl["dsp_wps_stop_sample"]._set_vector_unsafe(
+            loc, np.array(wps["dsp_stop_sample"], dtype="int32")[:wps_n_traces]
+        )
+        tbl["dsp_wps_dsp_max_margin_front"].nda[loc] = np.int32(
+            wps["dsp_max_margin_front"]
+        )
+        tbl["dsp_wps_dsp_max_margin_back"].nda[loc] = np.int32(
+            wps["dsp_max_margin_back"]
+        )
         tbl["dsp_wps_apply_gain_scaling"].nda[loc] = np.int32(wps["apply_gain_scaling"])
         tbl["dsp_wps_sum_window_size"].nda[loc] = np.int32(wps["sum_window_size"])
-        tbl["dsp_wps_sum_window_start_sample"].nda[loc] = np.int32(wps["sum_window_start_sample"])
-        tbl["dsp_wps_sum_window_stop_sample"].nda[loc] = np.int32(wps["sum_window_stop_sample"])
-        tbl["dsp_wps_sub_event_sum_threshold"].nda[loc] = np.float32(wps["sub_event_sum_threshold"])
+        tbl["dsp_wps_sum_window_start_sample"].nda[loc] = np.int32(
+            wps["sum_window_start_sample"]
+        )
+        tbl["dsp_wps_sum_window_stop_sample"].nda[loc] = np.int32(
+            wps["sum_window_stop_sample"]
+        )
+        tbl["dsp_wps_sub_event_sum_threshold"].nda[loc] = np.float32(
+            wps["sub_event_sum_threshold"]
+        )
         tbl["dsp_hwm_tracemap_format"].nda[loc] = np.int32(hwm["tracemap"]["format"])
-        tbl["dsp_hwm_tracemap_indices"]._set_vector_unsafe(loc, np.array(hwm["tracemap"]["map"], dtype="int32")[:hwm_n_traces])
-        tbl["dsp_hwm_tracemap_enabled"]._set_vector_unsafe(loc, np.array(hwm["tracemap"]["enabled"], dtype="int32")[
-            : hwm["tracemap"]["n_enabled"]
-        ])
+        tbl["dsp_hwm_tracemap_indices"]._set_vector_unsafe(
+            loc, np.array(hwm["tracemap"]["map"], dtype="int32")[:hwm_n_traces]
+        )
+        tbl["dsp_hwm_tracemap_enabled"]._set_vector_unsafe(
+            loc,
+            np.array(hwm["tracemap"]["enabled"], dtype="int32")[
+                : hwm["tracemap"]["n_enabled"]
+            ],
+        )
 
-        tbl["dsp_hwm_tracemap_label"].nda[loc][:] = np.array(hwm["tracemap"]["label"], dtype="|S7")
+        tbl["dsp_hwm_tracemap_label"].nda[loc][:] = np.array(
+            hwm["tracemap"]["label"], dtype="|S7"
+        )
 
-        tbl["dsp_hwm_fpga_energy_threshold_adc"]._set_vector_unsafe(loc, np.array(hwm["fpga_energy_threshold_adc"], dtype="uint16")[
-            :hwm_n_traces
-        ])
+        tbl["dsp_hwm_fpga_energy_threshold_adc"]._set_vector_unsafe(
+            loc,
+            np.array(hwm["fpga_energy_threshold_adc"], dtype="uint16")[:hwm_n_traces],
+        )
         tbl["dsp_ct_tracemap_format"].nda[loc] = np.int32(ct["tracemap"]["format"])
-        tbl["dsp_ct_tracemap_indices"]._set_vector_unsafe(loc, np.array(ct["tracemap"]["map"], dtype="int32")[:ct_n_traces])
-        tbl["dsp_ct_tracemap_enabled"]._set_vector_unsafe(loc, np.array(ct["tracemap"]["enabled"], dtype="int32")[
-            : ct["tracemap"]["n_enabled"]
-        ])
+        tbl["dsp_ct_tracemap_indices"]._set_vector_unsafe(
+            loc, np.array(ct["tracemap"]["map"], dtype="int32")[:ct_n_traces]
+        )
+        tbl["dsp_ct_tracemap_enabled"]._set_vector_unsafe(
+            loc,
+            np.array(ct["tracemap"]["enabled"], dtype="int32")[
+                : ct["tracemap"]["n_enabled"]
+            ],
+        )
 
-        tbl["dsp_ct_tracemap_label"].nda[loc][:] = np.array(ct["tracemap"]["label"], dtype="|S7")
+        tbl["dsp_ct_tracemap_label"].nda[loc][:] = np.array(
+            ct["tracemap"]["label"], dtype="|S7"
+        )
 
-        tbl["dsp_ct_thresholds"]._set_vector_unsafe(loc, np.array(ct["thresholds"], dtype="uint16")[:ct_n_traces])
+        tbl["dsp_ct_thresholds"]._set_vector_unsafe(
+            loc, np.array(ct["thresholds"], dtype="uint16")[:ct_n_traces]
+        )
 
         fsp_config_rb.loc += 1
 
@@ -452,7 +640,6 @@ class FSPConfigDecoder(DataDecoder):
 
     def make_lgdo(self, key: int | str = None, size: int = None) -> lgdo.Struct:
         return self.fsp_config
-
 
 
 fsp_status_decoded_values = {

--- a/src/daq2lh5/fc/fc_fsp_decoder.py
+++ b/src/daq2lh5/fc/fc_fsp_decoder.py
@@ -1,17 +1,15 @@
 from __future__ import annotations
 
 import copy
-import logging
-import numpy as np
 from typing import Any
 
-from daq2lh5.raw_buffer import RawBufferList
-from fcio import FCIO, Limits
 import lgdo
+import numpy as np
+from fcio import FCIO, Limits
 
-from .fc_eventheader_decoder import get_key
 
 from ..data_decoder import DataDecoder
+from .fc_eventheader_decoder import get_key
 
 fsp_config_decoded_values = {
     "packet_id": {

--- a/src/daq2lh5/fc/fc_fsp_decoder.py
+++ b/src/daq2lh5/fc/fc_fsp_decoder.py
@@ -7,7 +7,6 @@ import lgdo
 import numpy as np
 from fcio import FCIO, Limits
 
-
 from ..data_decoder import DataDecoder
 from .fc_eventheader_decoder import get_key
 

--- a/src/daq2lh5/fc/fc_fsp_decoder.py
+++ b/src/daq2lh5/fc/fc_fsp_decoder.py
@@ -13,11 +13,171 @@ from .fc_eventheader_decoder import get_key
 
 from ..data_decoder import DataDecoder
 
+fsp_config_decoded_values = {
+    "packet_id": {
+        "dtype": "uint32",
+        "description": "The index of this decoded packet in the file.",
+    },
+    "buffer_max_states" : { 'dtype' : 'int32', 'description' : ""},
+    "buffer_window_nsec" : { 'dtype' : 'int64', 'description' : ""},
+    "trg_hwm_min_multiplicity" : { 'dtype' : 'int32', 'description' : ""},
+    "trg_hwm_prescale_ratio" : { 'dtype' : 'int32', 'description' : ""},
+    "trg_wps_prescale_ratio" : { 'dtype' : 'int32', 'description' : ""},
+    "trg_wps_coincident_sum_threshold" : { 'dtype' : 'float32', 'description' : ""},
+    "trg_wps_sum_threshold" : { 'dtype' : 'float32', 'description' : ""},
+    "trg_wps_prescale_rate" : { 'dtype' : 'float32', 'description' : ""},
+    "trg_hwm_prescale_rate" : { 'dtype' : 'float32', 'description' : ""},
+    "trg_wps_ref_flags_hwm" : { 'dtype' : 'int64', 'description' : ""},
+    "trg_wps_ref_flags_ct" : { 'dtype' : 'int64', 'description' : ""},
+    "trg_wps_ref_flags_wps" : { 'dtype' : 'int64', 'description' : ""},
+    "trg_wps_ref_map_idx" : { 'dtype' : 'int32', "datatype": "array<1>{array<1>{real}}", "length_guess": Limits.MaxChannels, 'description' : ""},
+    "trg_enabled_write_flags_trigger" : { 'dtype' : 'int64', 'description' : ""},
+    "trg_enabled_write_flags_event" : { 'dtype' : 'int64', 'description' : ""},
+    "trg_pre_trigger_window_nsec" : { 'dtype' : 'int64', 'description' : ""},
+    "trg_post_trigger_window_nsec" : { 'dtype' : 'int64', 'description' : ""},
+    "dsp_wps_tracemap_format" : { 'dtype' : 'int32', 'description' : ""},
+    "dsp_wps_tracemap_indices" : { 'dtype' : 'int32', "datatype": "array<1>{array<1>{real}}", "length_guess": Limits.MaxChannels, 'description' : ""},
+    "dsp_wps_tracemap_enabled" : { 'dtype' : 'int32', "datatype": "array<1>{array<1>{real}}", "length_guess": Limits.MaxChannels, 'description' : ""},
+    "dsp_wps_tracemap_label" : { 'dtype' : '|S7', "datatype": "array<1>{array<1>{real}}", "length_guess": Limits.MaxChannels, 'description' : ""},
+    "dsp_wps_gains" : { 'dtype' : 'float32', "datatype": "array<1>{array<1>{real}}", "length_guess": Limits.MaxChannels, 'description' : ""},
+    "dsp_wps_thresholds" : { 'dtype' : 'float32', "datatype": "array<1>{array<1>{real}}", "length_guess": Limits.MaxChannels, 'description' : ""},
+    "dsp_wps_lowpass" : { 'dtype' : 'float32', "datatype": "array<1>{array<1>{real}}", "length_guess": Limits.MaxChannels, 'description' : ""},
+    "dsp_wps_shaping_widths" : { 'dtype' : 'int32', "datatype": "array<1>{array<1>{real}}", "length_guess": Limits.MaxChannels, 'description' : ""},
+    "dsp_wps_margin_front" : { 'dtype' : 'int32', "datatype": "array<1>{array<1>{real}}", "length_guess": Limits.MaxChannels, 'description' : ""},
+    "dsp_wps_margin_back" : { 'dtype' : 'int32', "datatype": "array<1>{array<1>{real}}", "length_guess": Limits.MaxChannels, 'description' : ""},
+    "dsp_wps_start_sample" : { 'dtype' : 'int32', "datatype": "array<1>{array<1>{real}}", "length_guess": Limits.MaxChannels, 'description' : ""},
+    "dsp_wps_stop_sample" : { 'dtype' : 'int32', "datatype": "array<1>{array<1>{real}}", "length_guess": Limits.MaxChannels, 'description' : ""},
+    "dsp_wps_dsp_max_margin_front" : { 'dtype' : 'int32', 'description' : ""},
+    "dsp_wps_dsp_max_margin_back" : { 'dtype' : 'int32', 'description' : ""},
+    "dsp_wps_apply_gain_scaling" : { 'dtype' : 'int32', 'description' : ""},
+    "dsp_wps_sum_window_size" : { 'dtype' : 'int32', 'description' : ""},
+    "dsp_wps_sum_window_start_sample" : { 'dtype' : 'int32', 'description' : ""},
+    "dsp_wps_sum_window_stop_sample" : { 'dtype' : 'int32', 'description' : ""},
+    "dsp_wps_sub_event_sum_threshold" : { 'dtype' : 'float32', 'description' : ""},
+    "dsp_hwm_tracemap_format" : { 'dtype' : 'int32', 'description' : ""},
+    "dsp_hwm_tracemap_indices" : { 'dtype' : 'int32', "datatype": "array<1>{array<1>{real}}", "length_guess": Limits.MaxChannels, 'description' : ""},
+    "dsp_hwm_tracemap_enabled" : { 'dtype' : 'int32', "datatype": "array<1>{array<1>{real}}", "length_guess": Limits.MaxChannels, 'description' : ""},
+    "dsp_hwm_tracemap_label" : { 'dtype' : '|S7', "datatype": "array<1>{array<1>{real}}", "length_guess": Limits.MaxChannels, 'description' : ""},
+    "dsp_hwm_fpga_energy_threshold_adc" : { 'dtype' : 'uint16', "datatype": "array<1>{array<1>{real}}", "length_guess": Limits.MaxChannels, 'description' : ""},
+    "dsp_ct_tracemap_format" : { 'dtype' : 'int32', 'description' : ""},
+    "dsp_ct_tracemap_indices" : { 'dtype' : 'int32', "datatype": "array<1>{array<1>{real}}", "length_guess": Limits.MaxChannels, 'description' : ""},
+    "dsp_ct_tracemap_enabled" : { 'dtype' : 'int32', "datatype": "array<1>{array<1>{real}}", "length_guess": Limits.MaxChannels, 'description' : ""},
+    "dsp_ct_tracemap_label" : { 'dtype' : '|S7', "datatype": "array<1>{array<1>{real}}", "length_guess": Limits.MaxChannels, 'description' : ""},
+    "dsp_ct_thresholds" : { 'dtype' : 'uint16', "datatype": "array<1>{array<1>{real}}", "length_guess": Limits.MaxChannels, 'description' : ""},
+}
+
 
 class FSPConfigDecoder(DataDecoder):
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
         self.fsp_config = lgdo.Struct()
+
+        self.decoded_values = copy.deepcopy(fsp_config_decoded_values)
+        self.key_list = []
+
+    def set_fcio_stream(self, fcio_stream: FCIO) -> None:
+        self.key_list = [f"fsp_config_{get_key(fcio_stream.config.streamid, 0, 0)}"]
+
+    def get_decoded_values(self, key: int = None) -> dict[str, dict[str, Any]]:
+        return self.decoded_values
+
+    def decode_packet(
+        self,
+        fcio: FCIO,
+        fsp_config_rb: lgdo.Table,
+        packet_id: int,
+    ) -> bool:
+
+        tbl = fsp_config_rb.lgdo
+        loc = fsp_config_rb.loc
+
+        # FSP: Buffer
+        buffer = fcio.fsp.config.buffer
+        # TriggerConfig
+        triggerconfig = fcio.fsp.config.triggerconfig
+        #  DSPWindowedPeakSum:
+        wps = fcio.fsp.config.wps
+        wps_n_traces = wps["tracemap"]["n_mapped"]
+        # DSPHardwareMajority:
+        hwm = fcio.fsp.config.hwm
+        hwm_n_traces = hwm["tracemap"]["n_mapped"]
+        # DSPChannelThreshold:
+        ct = fcio.fsp.config.ct
+        ct_n_traces = ct["tracemap"]["n_mapped"]
+
+        tbl["packet_id"].nda[loc] = packet_id
+
+        tbl["buffer_max_states"].nda[loc] = np.int32(buffer["max_states"])
+        tbl["buffer_window_nsec"].nda[loc] = np.int64(
+            buffer["buffer_window"]["seconds"] * 1e9
+            + buffer["buffer_window"]["nanoseconds"]
+        )
+        tbl["trg_hwm_min_multiplicity"].nda[loc] = np.int32(triggerconfig["hwm_min_multiplicity"])
+        tbl["trg_hwm_prescale_ratio"].nda[loc] = np.int32(triggerconfig["hwm_prescale_ratio"])
+        tbl["trg_wps_prescale_ratio"].nda[loc] = np.int32(triggerconfig["wps_prescale_ratio"])
+        tbl["trg_wps_coincident_sum_threshold"].nda[loc] = np.float32(triggerconfig["wps_coincident_sum_threshold"])
+        tbl["trg_wps_sum_threshold"].nda[loc] = np.float32(triggerconfig["wps_sum_threshold"])
+        tbl["trg_wps_prescale_rate"].nda[loc] = np.float32(triggerconfig["wps_prescale_rate"])
+        tbl["trg_hwm_prescale_rate"].nda[loc] = np.float32(triggerconfig["hwm_prescale_rate"])
+        tbl["trg_wps_ref_flags_hwm"].nda[loc] = np.int64(triggerconfig["wps_ref_flags_hwm"]["is_flagged"])
+        tbl["trg_wps_ref_flags_ct"].nda[loc] = np.int64(triggerconfig["wps_ref_flags_ct"]["is_flagged"])
+        tbl["trg_wps_ref_flags_wps"].nda[loc] = np.int64(triggerconfig["wps_ref_flags_wps"]["is_flagged"])
+        wps_ref_map_idx = np.array(triggerconfig["wps_ref_map_idx"], dtype="int32")[
+            : triggerconfig["n_wps_ref_map_idx"]
+        ]
+        tbl["trg_wps_ref_map_idx"]._set_vector_unsafe(loc, wps_ref_map_idx)
+
+        tbl["trg_enabled_write_flags_trigger"].nda[loc] = np.int64(triggerconfig["enabled_flags"]["trigger"]["is_flagged"])
+        tbl["trg_enabled_write_flags_event"].nda[loc] = np.int64(triggerconfig["enabled_flags"]["event"]["is_flagged"])
+        tbl["trg_pre_trigger_window_nsec"].nda[loc] = np.int64(
+            triggerconfig["pre_trigger_window"]["seconds"] * 1e9
+            + triggerconfig["pre_trigger_window"]["nanoseconds"]
+        )
+        tbl["trg_post_trigger_window_nsec"].nda[loc] = np.int64(
+            triggerconfig["post_trigger_window"]["seconds"] * 1e9
+            + triggerconfig["post_trigger_window"]["nanoseconds"]
+        )
+        tbl["dsp_wps_tracemap_format"].nda[loc] = np.int32(wps["tracemap"]["format"])
+        tbl["dsp_wps_tracemap_indices"]._set_vector_unsafe(loc, np.array(wps["tracemap"]["map"], dtype="int32")[:wps_n_traces])
+        tbl["dsp_wps_tracemap_enabled"]._set_vector_unsafe(loc, np.array(wps["tracemap"]["enabled"], dtype="int32")[
+            : wps["tracemap"]["n_enabled"]
+        ])
+        tbl["dsp_wps_tracemap_label"]._set_vector_unsafe(loc,np.array(wps["tracemap"]["label"], dtype="|S7")[:wps_n_traces])
+        tbl["dsp_wps_gains"]._set_vector_unsafe(loc,np.array(wps["gains"], dtype="float32")[:wps_n_traces])
+        tbl["dsp_wps_thresholds"]._set_vector_unsafe(loc,np.array(wps["thresholds"], dtype="float32")[:wps_n_traces])
+        tbl["dsp_wps_lowpass"]._set_vector_unsafe(loc,np.array(wps["lowpass"], dtype="float32")[:wps_n_traces])
+        tbl["dsp_wps_shaping_widths"]._set_vector_unsafe(loc,np.array(wps["shaping_widths"], dtype="int32")[:wps_n_traces])
+        tbl["dsp_wps_margin_front"]._set_vector_unsafe(loc,np.array(wps["dsp_margin_front"], dtype="int32")[:wps_n_traces])
+        tbl["dsp_wps_margin_back"]._set_vector_unsafe(loc,np.array(wps["dsp_margin_back"], dtype="int32")[:wps_n_traces])
+        tbl["dsp_wps_start_sample"]._set_vector_unsafe(loc,np.array(wps["dsp_start_sample"], dtype="int32")[:wps_n_traces])
+        tbl["dsp_wps_stop_sample"]._set_vector_unsafe(loc,np.array(wps["dsp_stop_sample"], dtype="int32")[:wps_n_traces])
+        tbl["dsp_wps_dsp_max_margin_front"].nda[loc] = np.int32(wps["dsp_max_margin_front"])
+        tbl["dsp_wps_dsp_max_margin_back"].nda[loc] = np.int32(wps["dsp_max_margin_back"])
+        tbl["dsp_wps_apply_gain_scaling"].nda[loc] = np.int32(wps["apply_gain_scaling"])
+        tbl["dsp_wps_sum_window_size"].nda[loc] = np.int32(wps["sum_window_size"])
+        tbl["dsp_wps_sum_window_start_sample"].nda[loc] = np.int32(wps["sum_window_start_sample"])
+        tbl["dsp_wps_sum_window_stop_sample"].nda[loc] = np.int32(wps["sum_window_stop_sample"])
+        tbl["dsp_wps_sub_event_sum_threshold"].nda[loc] = np.float32(wps["sub_event_sum_threshold"])
+        tbl["dsp_hwm_tracemap_format"].nda[loc] = np.int32(hwm["tracemap"]["format"])
+        tbl["dsp_hwm_tracemap_indices"]._set_vector_unsafe(loc, np.array(hwm["tracemap"]["map"], dtype="int32")[:hwm_n_traces])
+        tbl["dsp_hwm_tracemap_enabled"]._set_vector_unsafe(loc, np.array(hwm["tracemap"]["enabled"], dtype="int32")[
+            : hwm["tracemap"]["n_enabled"]
+        ])
+        tbl["dsp_hwm_tracemap_label"]._set_vector_unsafe(loc,  np.array(hwm["tracemap"]["label"], dtype="|S7")[:hwm_n_traces])
+        tbl["dsp_hwm_fpga_energy_threshold_adc"]._set_vector_unsafe(loc, np.array(hwm["fpga_energy_threshold_adc"], dtype="uint16")[
+            :hwm_n_traces
+        ])
+        tbl["dsp_ct_tracemap_format"].nda[loc] = np.int32(ct["tracemap"]["format"])
+        tbl["dsp_ct_tracemap_indices"]._set_vector_unsafe(loc, np.array(ct["tracemap"]["map"], dtype="int32")[:ct_n_traces])
+        tbl["dsp_ct_tracemap_enabled"]._set_vector_unsafe(loc, np.array(ct["tracemap"]["enabled"], dtype="int32")[
+            : ct["tracemap"]["n_enabled"]
+        ])
+        tbl["dsp_ct_tracemap_label"]._set_vector_unsafe(loc, np.array(ct["tracemap"]["label"], dtype="|S7")[:ct_n_traces])
+        tbl["dsp_ct_thresholds"]._set_vector_unsafe(loc, np.array(ct["thresholds"], dtype="uint16")[:ct_n_traces])
+
+        fsp_config_rb.loc += 1
+
+        return fsp_config_rb.is_full()
 
     def decode_config(self, fcio: FCIO) -> lgdo.Struct:
         # FSP: Buffer
@@ -263,6 +423,7 @@ class FSPConfigDecoder(DataDecoder):
         return self.fsp_config
 
 
+
 fsp_status_decoded_values = {
     "packet_id": {"dtype": "uint32"},
     "start_time": {"dtype": "float64"},
@@ -292,7 +453,7 @@ class FSPStatusDecoder(DataDecoder):
         self.key_list = []
 
     def set_fcio_stream(self, fcio_stream: FCIO) -> None:
-        self.key_list = [get_key(fcio_stream.config.streamid, 0, 0)]
+        self.key_list = [f"fsp_status_{get_key(fcio_stream.config.streamid, 0, 0)}"]
 
     def get_key_lists(self) -> list[list[int | str]]:
         return [copy.deepcopy(self.key_list)]
@@ -383,7 +544,7 @@ class FSPEventDecoder(DataDecoder):
 
     def set_fcio_stream(self, fcio_stream: FCIO) -> None:
 
-        self.key_list = [get_key(fcio_stream.config.streamid, 0, 0)]
+        self.key_list = [f"fsp_event_{get_key(fcio_stream.config.streamid, 0, 0)}"]
 
     def get_decoded_values(self, key: int = None) -> dict[str, dict[str, Any]]:
         return self.decoded_values

--- a/src/daq2lh5/fc/fc_fsp_decoder.py
+++ b/src/daq2lh5/fc/fc_fsp_decoder.py
@@ -1,0 +1,451 @@
+from __future__ import annotations
+
+import copy
+import logging
+import numpy as np
+from typing import Any
+
+from daq2lh5.raw_buffer import RawBufferList
+from fcio import FCIO, Limits
+import lgdo
+
+from .fc_eventheader_decoder import get_key
+
+from ..data_decoder import DataDecoder
+
+
+class FSPConfigDecoder(DataDecoder):
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        self.fsp_config = lgdo.Struct()
+
+    def decode_config(self, fcio: FCIO) -> lgdo.Struct:
+        # FSP: Buffer
+        buffer = fcio.fsp.config.buffer
+        self.fsp_config.add_field(
+            "buffer_max_states", lgdo.Scalar(np.int32(buffer["max_states"]))
+        )
+        self.fsp_config.add_field(
+            "buffer_window_nsec",
+            lgdo.Scalar(
+                np.int64(
+                    buffer["buffer_window"]["seconds"] * 1e9
+                    + buffer["buffer_window"]["nanoseconds"]
+                )
+            ),
+        )
+
+        # TriggerConfig
+        triggerconfig = fcio.fsp.config.triggerconfig
+        self.fsp_config.add_field(
+            "trg_hwm_min_multiplicity",
+            lgdo.Scalar(np.int32(triggerconfig["hwm_min_multiplicity"])),
+        )
+        self.fsp_config.add_field(
+            "trg_hwm_prescale_ratio",
+            lgdo.Scalar(np.int32(triggerconfig["hwm_prescale_ratio"])),
+        )
+        self.fsp_config.add_field(
+            "trg_wps_prescale_ratio",
+            lgdo.Scalar(np.int32(triggerconfig["wps_prescale_ratio"])),
+        )
+        self.fsp_config.add_field(
+            "trg_wps_coincident_sum_threshold",
+            lgdo.Scalar(np.float32(triggerconfig["wps_coincident_sum_threshold"])),
+        )
+        self.fsp_config.add_field(
+            "trg_wps_sum_threshold",
+            lgdo.Scalar(np.float32(triggerconfig["wps_sum_threshold"])),
+        )
+        self.fsp_config.add_field(
+            "trg_wps_prescale_rate",
+            lgdo.Scalar(np.float32(triggerconfig["wps_prescale_rate"])),
+        )
+        self.fsp_config.add_field(
+            "trg_hwm_prescale_rate",
+            lgdo.Scalar(np.float32(triggerconfig["hwm_prescale_rate"])),
+        )
+
+        self.fsp_config.add_field(
+            "trg_wps_ref_flags_hwm",
+            lgdo.Scalar(np.int64(triggerconfig["wps_ref_flags_hwm"]["is_flagged"])),
+        )
+        self.fsp_config.add_field(
+            "trg_wps_ref_flags_ct",
+            lgdo.Scalar(np.int64(triggerconfig["wps_ref_flags_ct"]["is_flagged"])),
+        )
+        self.fsp_config.add_field(
+            "trg_wps_ref_flags_wps",
+            lgdo.Scalar(np.int64(triggerconfig["wps_ref_flags_wps"]["is_flagged"])),
+        )
+
+        wps_ref_map_idx = np.array(triggerconfig["wps_ref_map_idx"], dtype="int32")[
+            : triggerconfig["n_wps_ref_map_idx"]
+        ]
+        self.fsp_config.add_field("trg_wps_ref_map_idx", lgdo.Array(wps_ref_map_idx))
+        self.fsp_config.add_field(
+            "trg_enabled_write_flags_trigger",
+            lgdo.Scalar(
+                np.int64(triggerconfig["enabled_flags"]["trigger"]["is_flagged"])
+            ),
+        )
+        self.fsp_config.add_field(
+            "trg_enabled_write_flags_event",
+            lgdo.Scalar(
+                np.int64(triggerconfig["enabled_flags"]["event"]["is_flagged"])
+            ),
+        )
+        self.fsp_config.add_field(
+            "trg_pre_trigger_window_nsec",
+            lgdo.Scalar(
+                np.int64(
+                    triggerconfig["pre_trigger_window"]["seconds"] * 1e9
+                    + triggerconfig["pre_trigger_window"]["nanoseconds"]
+                )
+            ),
+        )
+        self.fsp_config.add_field(
+            "trg_post_trigger_window_nsec",
+            lgdo.Scalar(
+                np.int64(
+                    triggerconfig["post_trigger_window"]["seconds"] * 1e9
+                    + triggerconfig["post_trigger_window"]["nanoseconds"]
+                )
+            ),
+        )
+
+        #  DSPWindowedPeakSum:
+        wps = fcio.fsp.config.wps
+        wps_n_traces = wps["tracemap"]["n_mapped"]
+        self.fsp_config.add_field(
+            "dsp_wps_tracemap_format", lgdo.Scalar(np.int32(wps["tracemap"]["format"]))
+        )
+        self.fsp_config.add_field(
+            "dsp_wps_tracemap_indices",
+            lgdo.Array(np.array(wps["tracemap"]["map"], dtype="int32")[:wps_n_traces]),
+        )
+        self.fsp_config.add_field(
+            "dsp_wps_tracemap_enabled",
+            lgdo.Array(
+                np.array(wps["tracemap"]["enabled"], dtype="int32")[
+                    : wps["tracemap"]["n_enabled"]
+                ]
+            ),
+        )
+        self.fsp_config.add_field(
+            "dsp_wps_tracemap_label",
+            lgdo.Array(np.array(wps["tracemap"]["label"], dtype="|S7")[:wps_n_traces]),
+        )
+
+        self.fsp_config.add_field(
+            "dsp_wps_gains",
+            lgdo.Array(np.array(wps["gains"], dtype="float32")[:wps_n_traces]),
+        )
+        self.fsp_config.add_field(
+            "dsp_wps_thresholds",
+            lgdo.Array(np.array(wps["thresholds"], dtype="float32")[:wps_n_traces]),
+        )
+        self.fsp_config.add_field(
+            "dsp_wps_lowpass",
+            lgdo.Array(np.array(wps["lowpass"], dtype="float32")[:wps_n_traces]),
+        )
+        self.fsp_config.add_field(
+            "dsp_wps_shaping_widths",
+            lgdo.Array(np.array(wps["shaping_widths"], dtype="int32")[:wps_n_traces]),
+        )
+        self.fsp_config.add_field(
+            "dsp_wps_margin_front",
+            lgdo.Array(np.array(wps["dsp_margin_front"], dtype="int32")[:wps_n_traces]),
+        )
+        self.fsp_config.add_field(
+            "dsp_wps_margin_back",
+            lgdo.Array(np.array(wps["dsp_margin_back"], dtype="int32")[:wps_n_traces]),
+        )
+        self.fsp_config.add_field(
+            "dsp_wps_start_sample",
+            lgdo.Array(np.array(wps["dsp_start_sample"], dtype="int32")[:wps_n_traces]),
+        )
+        self.fsp_config.add_field(
+            "dsp_wps_stop_sample",
+            lgdo.Array(np.array(wps["dsp_stop_sample"], dtype="int32")[:wps_n_traces]),
+        )
+
+        self.fsp_config.add_field(
+            "dsp_wps_dsp_max_margin_front",
+            lgdo.Scalar(np.int32(wps["dsp_max_margin_front"])),
+        )
+        self.fsp_config.add_field(
+            "dsp_wps_dsp_max_margin_back",
+            lgdo.Scalar(np.int32(wps["dsp_max_margin_back"])),
+        )
+        self.fsp_config.add_field(
+            "dsp_wps_apply_gain_scaling",
+            lgdo.Scalar(np.int32(wps["apply_gain_scaling"])),
+        )
+        self.fsp_config.add_field(
+            "dsp_wps_sum_window_size", lgdo.Scalar(np.int32(wps["sum_window_size"]))
+        )
+        self.fsp_config.add_field(
+            "dsp_wps_sum_window_start_sample",
+            lgdo.Scalar(np.int32(wps["sum_window_start_sample"])),
+        )
+        self.fsp_config.add_field(
+            "dsp_wps_sum_window_stop_sample",
+            lgdo.Scalar(np.int32(wps["sum_window_stop_sample"])),
+        )
+        self.fsp_config.add_field(
+            "dsp_wps_sub_event_sum_threshold",
+            lgdo.Scalar(np.float32(wps["sub_event_sum_threshold"])),
+        )
+
+        # DSPHardwareMajority:
+        hwm = fcio.fsp.config.hwm
+        hwm_n_traces = hwm["tracemap"]["n_mapped"]
+        self.fsp_config.add_field(
+            "dsp_hwm_tracemap_format", lgdo.Scalar(np.int32(hwm["tracemap"]["format"]))
+        )
+        self.fsp_config.add_field(
+            "dsp_hwm_tracemap_indices",
+            lgdo.Array(np.array(hwm["tracemap"]["map"], dtype="int32")[:hwm_n_traces]),
+        )
+        self.fsp_config.add_field(
+            "dsp_hwm_tracemap_enabled",
+            lgdo.Array(
+                np.array(hwm["tracemap"]["enabled"], dtype="int32")[
+                    : hwm["tracemap"]["n_enabled"]
+                ]
+            ),
+        )
+        self.fsp_config.add_field(
+            "dsp_hwm_tracemap_label",
+            lgdo.Array(np.array(hwm["tracemap"]["label"], dtype="|S7")[:hwm_n_traces]),
+        )
+
+        self.fsp_config.add_field(
+            "dsp_hwm_fpga_energy_threshold_adc",
+            lgdo.Array(
+                np.array(hwm["fpga_energy_threshold_adc"], dtype="uint16")[
+                    :hwm_n_traces
+                ]
+            ),
+        )
+
+        # DSPChannelThreshold:
+        ct = fcio.fsp.config.ct
+        ct_n_traces = ct["tracemap"]["n_mapped"]
+        self.fsp_config.add_field(
+            "dsp_ct_tracemap_format", lgdo.Scalar(np.int32(ct["tracemap"]["format"]))
+        )
+        self.fsp_config.add_field(
+            "dsp_ct_tracemap_indices",
+            lgdo.Array(np.array(ct["tracemap"]["map"], dtype="int32")[:ct_n_traces]),
+        )
+        self.fsp_config.add_field(
+            "dsp_ct_tracemap_enabled",
+            lgdo.Array(
+                np.array(ct["tracemap"]["enabled"], dtype="int32")[
+                    : ct["tracemap"]["n_enabled"]
+                ]
+            ),
+        )
+        self.fsp_config.add_field(
+            "dsp_ct_tracemap_label",
+            lgdo.Array(np.array(ct["tracemap"]["label"], dtype="|S7")[:ct_n_traces]),
+        )
+
+        self.fsp_config.add_field(
+            "dsp_ct_thresholds",
+            lgdo.Array(np.array(ct["thresholds"], dtype="uint16")[:ct_n_traces]),
+        )
+        return self.fsp_config
+
+    def make_lgdo(self, key: int | str = None, size: int = None) -> lgdo.Struct:
+        return self.fsp_config
+
+
+fsp_status_decoded_values = {
+    "packet_id": {"dtype": "uint32"},
+    "start_time": {"dtype": "float64"},
+    "log_time": {"dtype": "float64"},
+    "dt_logtime": {"dtype": "float64"},
+    "runtime": {"dtype": "float64"},
+    "n_read_events": {"dtype": "int32"},
+    "n_written_events": {"dtype": "int32"},
+    "n_discarded_events": {"dtype": "int32"},
+    "dt_n_read_events": {"dtype": "int32"},
+    "dt_n_written_events": {"dtype": "int32"},
+    "dt_n_discarded_events": {"dtype": "int32"},
+    "dt": {"dtype": "float64"},
+    "dt_rate_read_events": {"dtype": "float64"},
+    "dt_rate_write_events": {"dtype": "float64"},
+    "dt_rate_discard_events": {"dtype": "float64"},
+    "avg_rate_read_events": {"dtype": "float64"},
+    "avg_rate_write_events": {"dtype": "float64"},
+    "avg_rate_discard_events": {"dtype": "float64"},
+}
+
+
+class FSPStatusDecoder(DataDecoder):
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        self.decoded_values = copy.deepcopy(fsp_status_decoded_values)
+        self.key_list = []
+
+    def set_fcio_stream(self, fcio_stream: FCIO) -> None:
+        self.key_list = [get_key(fcio_stream.config.streamid, 0, 0)]
+
+    def get_key_lists(self) -> list[list[int | str]]:
+        return [copy.deepcopy(self.key_list)]
+
+    def get_decoded_values(self, key: int = None) -> dict[str, dict[str, Any]]:
+        return self.decoded_values
+
+    def decode_packet(
+        self,
+        fcio: FCIO,
+        fsp_status_rbkd: lgdo.Table | dict[int, lgdo.Table],
+        packet_id: int,
+    ) -> bool:
+
+        fsp_status_rb = fsp_status_rbkd[self.key_list[0]]
+
+        tbl = fsp_status_rb.lgdo
+        loc = fsp_status_rb.loc
+
+        tbl["packet_id"].nda[loc] = packet_id
+        tbl["start_time"].nda[loc] = fcio.fsp.status.start_time
+        tbl["log_time"].nda[loc] = fcio.fsp.status.log_time
+        tbl["dt_logtime"].nda[loc] = fcio.fsp.status.dt_logtime
+        tbl["runtime"].nda[loc] = fcio.fsp.status.runtime
+        tbl["n_read_events"].nda[loc] = fcio.fsp.status.n_read_events
+        tbl["n_written_events"].nda[loc] = fcio.fsp.status.n_written_events
+        tbl["n_discarded_events"].nda[loc] = fcio.fsp.status.n_discarded_events
+        tbl["dt_n_read_events"].nda[loc] = fcio.fsp.status.dt_n_read_events
+        tbl["dt_n_written_events"].nda[loc] = fcio.fsp.status.dt_n_written_events
+        tbl["dt_n_discarded_events"].nda[loc] = fcio.fsp.status.dt_n_discarded_events
+        tbl["dt"].nda[loc] = fcio.fsp.status.dt
+        tbl["dt_rate_read_events"].nda[loc] = fcio.fsp.status.dt_rate_read_events
+        tbl["dt_rate_write_events"].nda[loc] = fcio.fsp.status.dt_rate_write_events
+        tbl["dt_rate_discard_events"].nda[loc] = fcio.fsp.status.dt_rate_discard_events
+        tbl["avg_rate_read_events"].nda[loc] = fcio.fsp.status.avg_rate_read_events
+        tbl["avg_rate_write_events"].nda[loc] = fcio.fsp.status.avg_rate_write_events
+        tbl["avg_rate_discard_events"].nda[
+            loc
+        ] = fcio.fsp.status.avg_rate_discard_events
+
+        fsp_status_rb.loc += 1
+
+        return fsp_status_rb.is_full()
+
+
+fsp_event_decoded_values = {
+    "packet_id": {"dtype": "uint32", "description": ""},
+    "is_written": {"dtype": "bool", "description": ""},
+    "is_extended": {"dtype": "bool", "description": ""},
+    "is_consecutive": {"dtype": "bool", "description": ""},
+    "is_hwm_prescaled": {"dtype": "bool", "description": ""},
+    "is_hwm_multiplicity": {"dtype": "bool", "description": ""},
+    "is_wps_sum": {"dtype": "bool", "description": ""},
+    "is_wps_coincident_sum": {"dtype": "bool", "description": ""},
+    "is_wps_prescaled": {"dtype": "bool", "description": ""},
+    "is_ct_multiplicity": {"dtype": "bool", "description": ""},
+    "obs_wps_sum_value": {"dtype": "float32", "description": ""},
+    "obs_wps_sum_offset": {"dtype": "uint16", "description": ""},
+    "obs_wps_sum_multiplicity": {"dtype": "uint16", "description": ""},
+    "obs_wps_max_peak_value": {"dtype": "float32", "description": ""},
+    "obs_wps_max_peak_offset": {"dtype": "uint16", "description": ""},
+    "obs_hwm_multiplicity": {"dtype": "uint16", "description": ""},
+    "obs_hwm_max_value": {"dtype": "uint16", "description": ""},
+    "obs_hwm_min_value": {"dtype": "uint16", "description": ""},
+    "obs_ct_multiplicity": {"dtype": "uint32", "description": ""},
+    "obs_ct_trace_idx": {
+        "dtype": "uint16",
+        "datatype": "array<1>{array<1>{real}}",
+        "length_guess": Limits.MaxChannels,
+        "description": "",
+    },
+    "obs_ct_max": {
+        "dtype": "uint16",
+        "datatype": "array<1>{array<1>{real}}",
+        "length_guess": Limits.MaxChannels,
+        "description": "",
+    },
+    "obs_evt_nconsecutive": {"dtype": "int32", "description": ""},
+}
+
+
+class FSPEventDecoder(DataDecoder):
+
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        self.decoded_values = copy.deepcopy(fsp_event_decoded_values)
+        self.key_list = []
+
+    def set_fcio_stream(self, fcio_stream: FCIO) -> None:
+
+        self.key_list = [get_key(fcio_stream.config.streamid, 0, 0)]
+
+    def get_decoded_values(self, key: int = None) -> dict[str, dict[str, Any]]:
+        return self.decoded_values
+
+    def get_key_lists(self) -> list[list[int | str]]:
+        return [copy.deepcopy(self.key_list)]
+
+    def decode_packet(
+        self,
+        fcio: FCIO,
+        fsp_evt_rbkd: lgdo.Table | dict[int, lgdo.Table],
+        packet_id: int,
+    ) -> bool:
+
+        if self.key_list[0] in fsp_evt_rbkd:
+            fsp_evt_rb = fsp_evt_rbkd[self.key_list[0]]
+        else:
+            return False
+
+        tbl = fsp_evt_rb.lgdo
+        loc = fsp_evt_rb.loc
+
+        tbl["packet_id"].nda[loc] = packet_id
+        tbl["is_written"].nda[loc] = fcio.fsp.event.is_written
+        tbl["is_extended"].nda[loc] = fcio.fsp.event.is_extended
+        tbl["is_consecutive"].nda[loc] = fcio.fsp.event.is_consecutive
+        tbl["is_hwm_prescaled"].nda[loc] = fcio.fsp.event.is_hwm_prescaled
+        tbl["is_hwm_multiplicity"].nda[loc] = fcio.fsp.event.is_hwm_multiplicity
+        tbl["is_wps_sum"].nda[loc] = fcio.fsp.event.is_wps_sum
+        tbl["is_wps_coincident_sum"].nda[loc] = fcio.fsp.event.is_wps_coincident_sum
+        tbl["is_wps_prescaled"].nda[loc] = fcio.fsp.event.is_wps_prescaled
+        tbl["is_ct_multiplicity"].nda[loc] = fcio.fsp.event.is_ct_multiplicity
+
+        tbl["obs_wps_sum_value"].nda[loc] = fcio.fsp.event.obs_wps_sum_value
+        tbl["obs_wps_sum_offset"].nda[loc] = fcio.fsp.event.obs_wps_sum_offset
+        tbl["obs_wps_sum_multiplicity"].nda[
+            loc
+        ] = fcio.fsp.event.obs_wps_sum_multiplicity
+        tbl["obs_wps_max_peak_value"].nda[
+            loc
+        ] = fcio.fsp.event.obs_wps_max_single_peak_value
+        tbl["obs_wps_max_peak_offset"].nda[
+            loc
+        ] = fcio.fsp.event.obs_wps_max_single_peak_offset
+        tbl["obs_hwm_multiplicity"].nda[loc] = fcio.fsp.event.obs_hwm_multiplicity
+        tbl["obs_hwm_max_value"].nda[loc] = fcio.fsp.event.obs_hwm_max_value
+        tbl["obs_hwm_min_value"].nda[loc] = fcio.fsp.event.obs_hwm_min_value
+        tbl["obs_evt_nconsecutive"].nda[loc] = fcio.fsp.event.obs_evt_nconsecutive
+        tbl["obs_ct_multiplicity"].nda[loc] = fcio.fsp.event.obs_ct_multiplicity
+
+        lens = fcio.fsp.event.obs_ct_multiplicity
+        start = 0 if loc == 0 else tbl["obs_ct_trace_idx"].cumulative_length[loc - 1]
+        end = start + lens
+        if lens > 0:
+            tbl["obs_ct_trace_idx"].flattened_data.nda[
+                start:end
+            ] = fcio.fsp.event.obs_ct_trace_idx
+            tbl["obs_ct_max"].flattened_data.nda[start:end] = fcio.fsp.event.obs_ct_max
+
+        tbl["obs_ct_trace_idx"].cumulative_length[loc] = end
+        tbl["obs_ct_max"].cumulative_length[loc] = end
+
+        fsp_evt_rb.loc += 1
+
+        return fsp_evt_rb.is_full()

--- a/src/daq2lh5/fc/fc_fsp_decoder.py
+++ b/src/daq2lh5/fc/fc_fsp_decoder.py
@@ -682,11 +682,14 @@ class FSPStatusDecoder(DataDecoder):
     def decode_packet(
         self,
         fcio: FCIO,
-        fsp_status_rbkd: lgdo.Table | dict[int, lgdo.Table],
+        fsp_status_rbkd: dict[int, lgdo.Table],
         packet_id: int,
     ) -> bool:
 
-        fsp_status_rb = fsp_status_rbkd[self.key_list[0]]
+        key = f"fsp_status_{get_key(fcio.config.streamid, 0, 0)}"
+        if key not in fsp_status_rbkd:
+            return False
+        fsp_status_rb = fsp_status_rbkd[key]
 
         tbl = fsp_status_rb.lgdo
         loc = fsp_status_rb.loc
@@ -773,14 +776,14 @@ class FSPEventDecoder(DataDecoder):
     def decode_packet(
         self,
         fcio: FCIO,
-        fsp_evt_rbkd: lgdo.Table | dict[int, lgdo.Table],
+        fsp_evt_rbkd: dict[int, lgdo.Table],
         packet_id: int,
     ) -> bool:
 
-        if self.key_list[0] in fsp_evt_rbkd:
-            fsp_evt_rb = fsp_evt_rbkd[self.key_list[0]]
-        else:
+        key = f"fsp_event_{get_key(fcio.config.streamid, 0, 0)}"
+        if key not in fsp_evt_rbkd:
             return False
+        fsp_evt_rb = fsp_evt_rbkd[key]
 
         tbl = fsp_evt_rb.lgdo
         loc = fsp_evt_rb.loc

--- a/src/daq2lh5/fc/fc_status_decoder.py
+++ b/src/daq2lh5/fc/fc_status_decoder.py
@@ -122,16 +122,13 @@ fc_status_decoded_values = {
 
 
 def get_key(streamid, reqid):
-    """
-        Similar to eventdecder but one less 1e5 instead of 1e6 for the streamid shift
-    """
-    return (streamid & 0xFFFF) * 100000 + (reqid & 0xFFFF)
+    return (streamid & 0xFFFF) * 1000000 + (reqid & 0xFFFF)
 
 def get_fcid(key: int) -> int:
-    return int(key // 100000)
+    return int(key // 10000000)
 
 def get_reqid(key: int) -> int:
-    return int(key % 100000)
+    return int(key % 1000000)
 
 
 class FCStatusDecoder(DataDecoder):

--- a/src/daq2lh5/fc/fc_status_decoder.py
+++ b/src/daq2lh5/fc/fc_status_decoder.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import copy
 import logging
+from typing import Any
 
 import lgdo
 from fcio import FCIO

--- a/src/daq2lh5/fc/fc_status_decoder.py
+++ b/src/daq2lh5/fc/fc_status_decoder.py
@@ -102,7 +102,7 @@ fc_status_decoded_values = {
         "dtype": "int32",
         "units": "mC",
         "datatype": "array<1>{array<1>{real}}",
-        "length_guess": 2,  # max number of daugher cards - only for adc cards
+        "length_guess": 2,  # max number of daughter cards - only for adc cards
         "description": "If the card has adc daughter (piggy) boards mounted, each daughter has a temperature sensor.",
     },
     "cti_links": {

--- a/src/daq2lh5/fc/fc_status_decoder.py
+++ b/src/daq2lh5/fc/fc_status_decoder.py
@@ -3,11 +3,10 @@ from __future__ import annotations
 import copy
 import logging
 
-from fcio import FCIO
 import lgdo
+from fcio import FCIO
 
 from ..data_decoder import DataDecoder
-from ..raw_buffer import RawBuffer
 
 log = logging.getLogger(__name__)
 

--- a/src/daq2lh5/fc/fc_status_decoder.py
+++ b/src/daq2lh5/fc/fc_status_decoder.py
@@ -124,8 +124,10 @@ fc_status_decoded_values = {
 def get_key(streamid, reqid):
     return (streamid & 0xFFFF) * 1000000 + (reqid & 0xFFFF)
 
+
 def get_fcid(key: int) -> int:
     return int(key // 10000000)
+
 
 def get_reqid(key: int) -> int:
     return int(key % 1000000)

--- a/src/daq2lh5/fc/fc_streamer.py
+++ b/src/daq2lh5/fc/fc_streamer.py
@@ -197,7 +197,7 @@ class FCStreamer(DataStreamer):
         # FCIOConfigs contains header data (lengths) required to access
         # (Sparse)Event(Header) records.
         # The protocol allows updates of these settings within a datastream.
-        # Concatening of FCIO streams is supported here only if the FCIOConfig
+        # Concatenating of FCIO streams is supported here only if the FCIOConfig
         # is the same.
         if self.fcio.tag == Tags.Config or self.fcio.tag == Tags.FSPConfig:
             log.warning(

--- a/src/daq2lh5/fc/fc_streamer.py
+++ b/src/daq2lh5/fc/fc_streamer.py
@@ -3,16 +3,16 @@ from __future__ import annotations
 import logging
 
 import lgdo
+from fcio import FCIO, Tags
 
-from fcio import FCIO, Tags, Limits
 from ..data_decoder import DataDecoder
 from ..data_streamer import DataStreamer
 from ..raw_buffer import RawBuffer, RawBufferLibrary
 from .fc_config_decoder import FCConfigDecoder
 from .fc_event_decoder import FCEventDecoder
 from .fc_eventheader_decoder import FCEventHeaderDecoder
-from .fc_status_decoder import FCStatusDecoder
 from .fc_fsp_decoder import FSPConfigDecoder, FSPEventDecoder, FSPStatusDecoder
+from .fc_status_decoder import FCStatusDecoder
 
 log = logging.getLogger(__name__)
 

--- a/src/daq2lh5/fc/fc_streamer.py
+++ b/src/daq2lh5/fc/fc_streamer.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import logging
 
+import lgdo
+
 from fcio import FCIO, Tags, Limits
 from ..data_decoder import DataDecoder
 from ..data_streamer import DataStreamer
@@ -156,13 +158,14 @@ class FCStreamer(DataStreamer):
             # It seems like the `loc` of the RawBuffer is used as `len`
             # for individual elements in a `lgdo.Struct` while writing.
             # Search for longest and use as `loc` attr.
-            max_length = max(
-                [
-                    len(entry) if hasattr(entry, "__len__") else 1
-                    for entry in config_lgdo.values()
-                ]
-            )
-            rb.loc = max_length
+            if isinstance(config_lgdo, lgdo.Struct):
+                max_length = max(
+                    [
+                        len(entry) if hasattr(entry, "__len__") else 1
+                        for entry in config_lgdo.values()
+                    ]
+                )
+                rb.loc = max_length
             rbs.append(rb)
         return rbs
 

--- a/src/daq2lh5/orca/orca_fcio.py
+++ b/src/daq2lh5/orca/orca_fcio.py
@@ -179,8 +179,7 @@ class ORFCIOStatusDecoder(OrcaDecoder):
 
         for fcid in self.fc_hdr_info['n_card']:
             # If the data was taken without a master distribution module,
-            # i.e. only one ADC Module the decoder will just not write to the
-            # Buffer.
+            # i.e. only one ADC Module the decoder will just not write to the buffer.
 
             # MDB key
             self.key_list['fc_status'] = [get_status_key(fcid, 0)]

--- a/src/daq2lh5/orca/orca_fcio.py
+++ b/src/daq2lh5/orca/orca_fcio.py
@@ -222,9 +222,6 @@ class ORFCIOStatusDecoder(OrcaDecoder):
         fcio_stream = get_fcio_stream(packet[2])
         fcio_stream.set_mem_field(memoryview(packet[3:]))
 
-        # self.decoder.set_fcio_stream(fcio_stream)
-        # self.fsp_decoder.set_fcio_stream(fcio_stream)
-
         any_full = False
         while fcio_stream.get_record():
             if fcio_stream.tag == Tags.Status:
@@ -316,7 +313,6 @@ class ORFCIOEventDecoder(OrcaDecoder):
     def set_header(self, header: OrcaHeader) -> None:
         """Setter for headers. Overload to set card parameters, etc."""
         self.header = header
-        # self.key_list = copy.deepcopy(self.decoder.get_key_lists())
         self.fc_hdr_info = extract_header_information(header)
         key_list = self.fc_hdr_info['key_list']
         for fcid in key_list:

--- a/src/daq2lh5/orca/orca_fcio.py
+++ b/src/daq2lh5/orca/orca_fcio.py
@@ -6,11 +6,7 @@ from fcio import FCIO, Tags
 
 from daq2lh5.fc.fc_config_decoder import FCConfigDecoder
 from daq2lh5.fc.fc_event_decoder import FCEventDecoder
-from daq2lh5.fc.fc_eventheader_decoder import (
-    FCEventHeaderDecoder,
-    get_fcid,
-    get_key,
-)
+from daq2lh5.fc.fc_eventheader_decoder import FCEventHeaderDecoder, get_fcid, get_key
 from daq2lh5.fc.fc_fsp_decoder import (
     FSPConfigDecoder,
     FSPEventDecoder,

--- a/src/daq2lh5/orca/orca_fcio.py
+++ b/src/daq2lh5/orca/orca_fcio.py
@@ -1,34 +1,35 @@
 import copy
-import gc
 import logging
 from typing import Any
-import copy
 
-import numpy as np
-
-from fcio import Limits, Tags, FCIO
+from fcio import FCIO, Tags
 
 from daq2lh5.fc.fc_config_decoder import FCConfigDecoder
 from daq2lh5.fc.fc_event_decoder import FCEventDecoder
-from daq2lh5.fc.fc_fsp_decoder import FSPConfigDecoder, FSPEventDecoder, FSPStatusDecoder
-from daq2lh5.fc.fc_eventheader_decoder import FCEventHeaderDecoder, get_key, get_fcid, get_card_address, get_card_input
-
+from daq2lh5.fc.fc_eventheader_decoder import (
+    FCEventHeaderDecoder,
+    get_fcid,
+    get_key,
+)
+from daq2lh5.fc.fc_fsp_decoder import (
+    FSPConfigDecoder,
+    FSPEventDecoder,
+    FSPStatusDecoder,
+)
 from daq2lh5.fc.fc_status_decoder import FCStatusDecoder
 from daq2lh5.fc.fc_status_decoder import get_key as get_status_key
-from daq2lh5.fc.fc_status_decoder import get_fcid as get_status_fcid
 
-from ..raw_buffer import RawBufferLibrary, RawBufferList, RawBuffer
+from ..raw_buffer import RawBufferList
 from .orca_base import OrcaDecoder
 from .orca_header import OrcaHeader
-from .orca_packet import OrcaPacket, is_extended
-
-import lgdo
+from .orca_packet import OrcaPacket
 
 log = logging.getLogger(__name__)
 
 
 # FCIO streams are stateful and need to be accessible for all decoders.
 fcio_stream_library = dict()
+
 
 def get_fcio_stream(streamid):
     if streamid in fcio_stream_library:
@@ -37,33 +38,39 @@ def get_fcio_stream(streamid):
         fcio_stream_library[streamid] = FCIO()
         return fcio_stream_library[streamid]
 
+
 def extract_header_information(header: OrcaHeader):
 
     fc_hdr_info = {
-      "key_list" : {},
-      "n_adc" : {},
-      "adc_card_layout" : {},
-      "wf_len" : {},
-      "fsp_enabled": {},
-      "n_card" : {},
+        "key_list": {},
+        "n_adc": {},
+        "adc_card_layout": {},
+        "wf_len": {},
+        "fsp_enabled": {},
+        "n_card": {},
     }
 
-    fc_card_info_dict = header.get_object_info([
-        "ORFlashCamGlobalTriggerModel",
-        "ORFlashCamTriggerModel",
-        "ORFlashCamADCModel",
-        "ORFlashCamADCStdModel",
-        ])
-
+    fc_card_info_dict = header.get_object_info(
+        [
+            "ORFlashCamGlobalTriggerModel",
+            "ORFlashCamTriggerModel",
+            "ORFlashCamADCModel",
+            "ORFlashCamADCStdModel",
+        ]
+    )
 
     fc_listener_info_list = header.get_readout_info("ORFlashCamListenerModel")
     for fc_listener_info in fc_listener_info_list:
-        fcid = fc_listener_info["uniqueID"] # it should be called listener_id
+        fcid = fc_listener_info["uniqueID"]  # it should be called listener_id
         if fcid == 0:
             raise ValueError("got fcid=0 unexpectedly!")
-        fc_hdr_info["fsp_enabled"][fcid] = header.get_auxhw_info("ORFlashCamListenerModel", fcid)["fspEnabled"]
+        fc_hdr_info["fsp_enabled"][fcid] = header.get_auxhw_info(
+            "ORFlashCamListenerModel", fcid
+        )["fspEnabled"]
 
-        fc_hdr_info["wf_len"][fcid] = header.get_auxhw_info("ORFlashCamListenerModel", fcid)["eventSamples"]
+        fc_hdr_info["wf_len"][fcid] = header.get_auxhw_info(
+            "ORFlashCamListenerModel", fcid
+        )["eventSamples"]
         fc_hdr_info["n_adc"][fcid] = 0
         fc_hdr_info["n_card"][fcid] = 0
         fc_hdr_info["key_list"][fcid] = []
@@ -73,7 +80,11 @@ def extract_header_information(header: OrcaHeader):
             crate = child["crate"]
             card = child["station"]
             card_address = fc_card_info_dict[crate][card]["CardAddress"]
-            fc_hdr_info["adc_card_layout"][fcid][card_address] = (crate, card, card_address)
+            fc_hdr_info["adc_card_layout"][fcid][card_address] = (
+                crate,
+                card,
+                card_address,
+            )
             fc_hdr_info["n_card"][fcid] += 1
 
             if crate not in fc_card_info_dict:
@@ -93,9 +104,7 @@ def extract_header_information(header: OrcaHeader):
                 else:
                     fc_hdr_info["key_list"][fcid].append(key)
 
-
     return fc_hdr_info
-
 
 
 class ORFCIOConfigDecoder(OrcaDecoder):
@@ -103,10 +112,7 @@ class ORFCIOConfigDecoder(OrcaDecoder):
 
         self.decoder = FCConfigDecoder()
         self.decoded_values = {}
-        self.key_list = {
-          'fc_config' : [],
-          'fsp_config' : []
-        }
+        self.key_list = {"fc_config": [], "fsp_config": []}
         self.max_rows_in_packet = 0
 
         super().__init__(header=header, **kwargs)
@@ -116,19 +122,19 @@ class ORFCIOConfigDecoder(OrcaDecoder):
         self.fc_hdr_info = extract_header_information(header)
         self.decoded_values = copy.deepcopy(self.decoder.get_decoded_values())
 
-        for fcid in self.fc_hdr_info['fsp_enabled']:
+        for fcid in self.fc_hdr_info["fsp_enabled"]:
             key = get_key(fcid, 0, 0)
-            self.key_list['fc_config'].append(key)
+            self.key_list["fc_config"].append(key)
             if self.fc_hdr_info["fsp_enabled"][fcid]:
                 self.fsp_decoder = FSPConfigDecoder()
-                self.key_list['fsp_config'].append(f"fsp_config_{key}")
+                self.key_list["fsp_config"].append(f"fsp_config_{key}")
         self.max_rows_in_packet = 1
 
-    def get_key_lists(self) -> list[list[int|str]]:
+    def get_key_lists(self) -> list[list[int | str]]:
         return list(self.key_list.values())
 
     def get_decoded_values(self, key: int | str = None) -> dict[str, Any]:
-        if isinstance(key,str) and key.startswith('fsp_config'):
+        if isinstance(key, str) and key.startswith("fsp_config"):
             return copy.deepcopy(self.fsp_decoder.get_decoded_values())
         return self.decoded_values
         raise KeyError(f"no decoded values for key {key}")
@@ -139,24 +145,31 @@ class ORFCIOConfigDecoder(OrcaDecoder):
 
         fcio_stream = get_fcio_stream(packet[2])
         if fcio_stream.is_open():
-            raise NotImplementedError(f"FCIO stream with stream id {packet[2]} already opened. Update of FCIOConfig is not supported.")
+            raise NotImplementedError(
+                f"FCIO stream with stream id {packet[2]} already opened. Update of FCIOConfig is not supported."
+            )
         else:
             fcio_stream.open(memoryview(packet[3:]))
 
         if fcio_stream.config.streamid != packet[2]:
-            log.warning(f"The expected stream id {packet[2]} does not match the contained stream id {fcio_stream.config.streamid}")
+            log.warning(
+                f"The expected stream id {packet[2]} does not match the contained stream id {fcio_stream.config.streamid}"
+            )
 
         config_rbkd = rbl.get_keyed_dict()
 
         # TODO: the decoders could fetch lgdo's using it's key_list
         fc_key = get_key(fcio_stream.config.streamid, 0, 0)
-        any_full = self.decoder.decode_packet(fcio_stream, config_rbkd[fc_key], packet_id)
+        any_full = self.decoder.decode_packet(
+            fcio_stream, config_rbkd[fc_key], packet_id
+        )
         if self.fsp_decoder is not None:
             fsp_key = f"fsp_config_{get_key(fcio_stream.config.streamid, 0, 0)}"
-            any_full |= self.fsp_decoder.decode_packet(fcio_stream, config_rbkd[fsp_key], packet_id)
+            any_full |= self.fsp_decoder.decode_packet(
+                fcio_stream, config_rbkd[fsp_key], packet_id
+            )
 
         return bool(any_full)
-
 
 
 class ORFCIOStatusDecoder(OrcaDecoder):
@@ -164,10 +177,7 @@ class ORFCIOStatusDecoder(OrcaDecoder):
 
         self.decoder = FCStatusDecoder()
         self.decoded_values = {}
-        self.key_list = {
-          'fc_status' : [],
-          'fsp_status' : []
-        }
+        self.key_list = {"fc_status": [], "fsp_status": []}
         self.max_rows_in_packet = 0
         super().__init__(header=header, **kwargs)
 
@@ -177,22 +187,25 @@ class ORFCIOStatusDecoder(OrcaDecoder):
         self.fc_hdr_info = extract_header_information(header)
         self.decoded_values = copy.deepcopy(self.decoder.get_decoded_values())
 
-        for fcid in self.fc_hdr_info['n_card']:
+        for fcid in self.fc_hdr_info["n_card"]:
             # If the data was taken without a master distribution module,
             # i.e. only one ADC Module the decoder will just not write to the buffer.
 
             # MDB key
-            self.key_list['fc_status'] = [get_status_key(fcid, 0)]
+            self.key_list["fc_status"] = [get_status_key(fcid, 0)]
             # ADC module keys
-            self.key_list['fc_status'] += [get_status_key(fcid, 0x2000 + i) for i in range(self.fc_hdr_info['n_card'][fcid])]
+            self.key_list["fc_status"] += [
+                get_status_key(fcid, 0x2000 + i)
+                for i in range(self.fc_hdr_info["n_card"][fcid])
+            ]
 
             if self.fc_hdr_info["fsp_enabled"][fcid]:
                 key = get_key(fcid, 0, 0)
-                self.key_list['fsp_status'].append(f"fsp_status_{key}")
+                self.key_list["fsp_status"].append(f"fsp_status_{key}")
                 self.fsp_decoder = FSPStatusDecoder()
         self.max_rows_in_packet = max(self.fc_hdr_info["n_card"].values()) + 1
 
-    def get_key_lists(self) -> list[list[int|str]]:
+    def get_key_lists(self) -> list[list[int | str]]:
         return list(self.key_list.values())
 
     def get_decoded_values(self, key: int | str = None) -> dict[str, Any]:
@@ -202,13 +215,16 @@ class ORFCIOStatusDecoder(OrcaDecoder):
                 return dec_vals_list[0]
             raise RuntimeError("decoded_values not built")
 
-        if isinstance(key, str) and key.startswith("fsp_status") and self.fsp_decoder is not None:
+        if (
+            isinstance(key, str)
+            and key.startswith("fsp_status")
+            and self.fsp_decoder is not None
+        ):
             return copy.deepcopy(self.fsp_decoder.get_decoded_values())
         elif isinstance(key, int):
             return copy.deepcopy(self.decoder.get_decoded_values())
         else:
             raise KeyError(f"no decoded values for key {key}")
-
 
     def get_max_rows_in_packet(self) -> int:
         return self.max_rows_in_packet
@@ -224,12 +240,15 @@ class ORFCIOStatusDecoder(OrcaDecoder):
         any_full = False
         while fcio_stream.get_record():
             if fcio_stream.tag == Tags.Status:
-                any_full |= self.decoder.decode_packet(fcio_stream, status_rbkd, packet_id)
+                any_full |= self.decoder.decode_packet(
+                    fcio_stream, status_rbkd, packet_id
+                )
                 if self.fsp_decoder is not None:
-                    any_full |= self.fsp_decoder.decode_packet(fcio_stream, status_rbkd, packet_id)
+                    any_full |= self.fsp_decoder.decode_packet(
+                        fcio_stream, status_rbkd, packet_id
+                    )
 
         return bool(any_full)
-
 
 
 class ORFCIOEventHeaderDecoder(OrcaDecoder):
@@ -238,10 +257,7 @@ class ORFCIOEventHeaderDecoder(OrcaDecoder):
         self.decoder = FCEventHeaderDecoder()
         self.fsp_decoder = None
         self.decoded_values = {}
-        self.key_list = {
-          'fc_eventheader' : [],
-          'fsp_event' : []
-        }
+        self.key_list = {"fc_eventheader": [], "fsp_event": []}
 
         super().__init__(header=header, **kwargs)
 
@@ -251,27 +267,31 @@ class ORFCIOEventHeaderDecoder(OrcaDecoder):
 
         self.fc_hdr_info = extract_header_information(header)
 
-        key_list = self.fc_hdr_info['key_list']
+        key_list = self.fc_hdr_info["key_list"]
         for fcid in key_list:
             key = get_key(fcid, 0, 0)
-            self.key_list['fc_eventheader'].append(key)
+            self.key_list["fc_eventheader"].append(key)
             self.decoded_values[fcid] = copy.deepcopy(self.decoder.get_decoded_values())
             if self.fc_hdr_info["fsp_enabled"][fcid]:
                 self.fsp_decoder = FSPEventDecoder()
-                self.key_list['fsp_event'].append(f"fsp_event_{key}")
+                self.key_list["fsp_event"].append(f"fsp_event_{key}")
 
         self.max_rows_in_packet = 1
 
-    def get_key_lists(self) -> list[list[int|str]]:
+    def get_key_lists(self) -> list[list[int | str]]:
         return list(self.key_list.values())
 
     def get_decoded_values(self, key: int | str = None) -> dict[str, Any]:
-        if isinstance(key, str) and key.startswith("fsp_event") and self.fsp_decoder is not None:
+        if (
+            isinstance(key, str)
+            and key.startswith("fsp_event")
+            and self.fsp_decoder is not None
+        ):
             return copy.deepcopy(self.fsp_decoder.get_decoded_values())
         elif isinstance(key, int):
             fcid = get_fcid(key)
             if fcid in self.decoded_values:
-              return self.decoded_values[fcid]
+                return self.decoded_values[fcid]
 
         raise KeyError(f"no decoded values for key {key}")
 
@@ -285,12 +305,15 @@ class ORFCIOEventHeaderDecoder(OrcaDecoder):
         any_full = False
         while fcio_stream.get_record():
             if fcio_stream.tag == Tags.EventHeader:
-                any_full |= self.decoder.decode_packet(fcio_stream, evthdr_rbkd, packet_id)
+                any_full |= self.decoder.decode_packet(
+                    fcio_stream, evthdr_rbkd, packet_id
+                )
                 if self.fsp_decoder is not None:
-                    any_full |= self.fsp_decoder.decode_packet(fcio_stream, evthdr_rbkd, packet_id)
+                    any_full |= self.fsp_decoder.decode_packet(
+                        fcio_stream, evthdr_rbkd, packet_id
+                    )
 
         return bool(any_full)
-
 
 
 class ORFCIOEventDecoder(OrcaDecoder):
@@ -300,10 +323,7 @@ class ORFCIOEventDecoder(OrcaDecoder):
         self.decoder = FCEventDecoder()
         self.fsp_decoder = None
 
-        self.key_list = {
-          'event' : [],
-          'fsp_event' : []
-        }
+        self.key_list = {"event": [], "fsp_event": []}
         self.decoded_values = {}
         self.max_rows_in_packet = 0
 
@@ -313,14 +333,16 @@ class ORFCIOEventDecoder(OrcaDecoder):
         """Setter for headers. Overload to set card parameters, etc."""
         self.header = header
         self.fc_hdr_info = extract_header_information(header)
-        key_list = self.fc_hdr_info['key_list']
+        key_list = self.fc_hdr_info["key_list"]
         for fcid in key_list:
-            self.key_list['event'] += key_list[fcid]
+            self.key_list["event"] += key_list[fcid]
             self.decoded_values[fcid] = copy.deepcopy(self.decoder.get_decoded_values())
-            self.decoded_values[fcid]["waveform"]["wf_len"] = self.fc_hdr_info["wf_len"][fcid]
+            self.decoded_values[fcid]["waveform"]["wf_len"] = self.fc_hdr_info[
+                "wf_len"
+            ][fcid]
             if self.fc_hdr_info["fsp_enabled"][fcid]:
                 key = get_key(fcid, 0, 0)
-                self.key_list['fsp_event'].append(f"fsp_event_{key}")
+                self.key_list["fsp_event"].append(f"fsp_event_{key}")
                 self.fsp_decoder = FSPEventDecoder()
         self.max_rows_in_packet = max(self.fc_hdr_info["n_adc"].values())
 
@@ -337,7 +359,11 @@ class ORFCIOEventDecoder(OrcaDecoder):
                 return dec_vals_list[0]
             raise RuntimeError("decoded_values not built")
 
-        if isinstance(key, str) and key.startswith("fsp_event") and self.fsp_decoder is not None:
+        if (
+            isinstance(key, str)
+            and key.startswith("fsp_event")
+            and self.fsp_decoder is not None
+        ):
             return copy.deepcopy(self.fsp_decoder.get_decoded_values())
         elif isinstance(key, int):
             fcid = get_fcid(key)
@@ -360,6 +386,8 @@ class ORFCIOEventDecoder(OrcaDecoder):
             if fcio_stream.tag == Tags.Event or fcio_stream.tag == Tags.SparseEvent:
                 any_full |= self.decoder.decode_packet(fcio_stream, evt_rbkd, packet_id)
                 if self.fsp_decoder is not None:
-                    any_full |= self.fsp_decoder.decode_packet(fcio_stream, evt_rbkd, packet_id)
+                    any_full |= self.fsp_decoder.decode_packet(
+                        fcio_stream, evt_rbkd, packet_id
+                    )
 
         return bool(any_full)

--- a/src/daq2lh5/orca/orca_fcio.py
+++ b/src/daq2lh5/orca/orca_fcio.py
@@ -1,0 +1,345 @@
+import copy
+import gc
+import logging
+from typing import Any
+import copy
+
+import numpy as np
+
+from fcio import Limits, Tags, FCIO
+
+from daq2lh5.fc.fc_config_decoder import FCConfigDecoder
+from daq2lh5.fc.fc_event_decoder import FCEventDecoder
+from daq2lh5.fc.fc_fsp_decoder import FSPConfigDecoder, FSPEventDecoder, FSPStatusDecoder
+from daq2lh5.fc.fc_eventheader_decoder import FCEventHeaderDecoder, get_key, get_fcid, get_card_address, get_card_input
+
+from daq2lh5.fc.fc_status_decoder import FCStatusDecoder
+from daq2lh5.fc.fc_status_decoder import get_key as get_status_key
+from daq2lh5.fc.fc_status_decoder import get_fcid as get_status_fcid
+
+from ..raw_buffer import RawBufferLibrary, RawBufferList, RawBuffer
+from .orca_base import OrcaDecoder
+from .orca_header import OrcaHeader
+from .orca_packet import OrcaPacket, is_extended
+
+import lgdo
+
+log = logging.getLogger(__name__)
+
+
+# using multiple decoders for the FCIO stream
+# requires storing the FCIO object (and it's state) globally
+fcio_stream_library = dict()
+
+def get_fcio_stream(streamid):
+    if streamid in fcio_stream_library:
+        return fcio_stream_library[streamid]
+    else:
+        fcio_stream_library[streamid] = FCIO()
+        return fcio_stream_library[streamid]
+
+def extract_header_information(header: OrcaHeader):
+
+    fc_hdr_info = {
+      "key_list" : {}, # access by fcid
+      "n_adc" : {},
+      "adc_card_layout" : {}, # [fcid][key] = (crate, card, cardaddress)
+      "wf_len" : {}, # [fcid] = wf_len
+      "fsp_enabled": {}, # [fcid]
+      "n_card" : {},
+    }
+
+    fc_card_info_dict = header.get_object_info([
+        "ORFlashCamGlobalTriggerModel",
+        "ORFlashCamTriggerModel",
+        "ORFlashCamADCModel",
+        "ORFlashCamADCStdModel",
+        ])
+
+
+    log.debug(f"CardInfoDict")
+    for crate in fc_card_info_dict:
+        for card in fc_card_info_dict[crate]:
+            log.debug(f"crate {crate} card {card} {fc_card_info_dict[crate][card]}")
+
+    fc_listener_info_list = header.get_readout_info("ORFlashCamListenerModel")
+    for fc_listener_info in fc_listener_info_list:
+        fcid = fc_listener_info["uniqueID"] # it should be called listener_id
+        if fcid == 0:
+            raise ValueError("got fcid=0 unexpectedly!")
+        fc_hdr_info["fsp_enabled"][fcid] = header.get_auxhw_info("ORFlashCamListenerModel", fcid)["fspEnabled"]
+
+        # get FC card object info from header to use below
+        # gives access like fc_info[crate][card]
+
+        fc_hdr_info["wf_len"][fcid] = header.get_auxhw_info("ORFlashCamListenerModel", fcid)["eventSamples"]
+        fc_hdr_info["n_adc"][fcid] = 0
+        fc_hdr_info["n_card"][fcid] = 0
+        fc_hdr_info["key_list"][fcid] = []
+        fc_hdr_info["adc_card_layout"][fcid] = {}
+        for child in fc_listener_info["children"]:
+
+            crate = child["crate"]
+            card = child["station"]
+            card_address = fc_card_info_dict[crate][card]["CardAddress"]
+            fc_hdr_info["adc_card_layout"][fcid][card_address] = (crate, card, card_address)
+            fc_hdr_info["n_card"][fcid] += 1
+
+            log.debug(f"fcid {fcid} has crate {crate} card {card} {fc_card_info_dict[crate][card]['Class Name']}")
+
+            if crate not in fc_card_info_dict:
+                raise RuntimeError(f"no crate {crate} in fc_card_info_dict")
+            if card not in fc_card_info_dict[crate]:
+                raise RuntimeError(f"no card {card} in fc_card_info_dict[{crate}]")
+
+            for fc_input in range(len(fc_card_info_dict[crate][card]["Enabled"])):
+                if not fc_card_info_dict[crate][card]["Enabled"][fc_input]:
+                    continue
+
+                fc_hdr_info["n_adc"][fcid] += 1
+                key = get_key(fcid, card_address, fc_input)
+
+                if key in fc_hdr_info["key_list"][fcid]:
+                    log.warning(f"key {key} already in key_list...")
+                else:
+                    fc_hdr_info["key_list"][fcid].append(key)
+
+
+    return fc_hdr_info
+
+
+
+class ORFCIOConfigDecoder(OrcaDecoder):
+    def __init__(self, header: OrcaHeader = None, **kwargs) -> None:
+
+        self.decoder = FCConfigDecoder()
+        self.decoded_values = {}
+
+        super().__init__(header=header, **kwargs)
+
+    def set_header(self, header: OrcaHeader) -> None:
+        self.header = header
+        self.decoded_values = copy.deepcopy(self.decoder.get_decoded_values())
+
+    def decode_packet(
+        self, packet: OrcaPacket, packet_id: int, rbl: RawBufferList
+    ) -> bool:
+
+        fcio_stream = get_fcio_stream(packet[2])
+        if fcio_stream.is_open():
+            log.warning(f"FCIO stream with stream id {packet[2]} already opened. Continue with updated FCIOConfig.")
+            fcio_stream.set_mem_field(memoryview(packet[3:]))
+        else:
+            fcio_stream.open(memoryview(packet[3:]))
+
+        if fcio_stream.config.streamid != packet[2]:
+            log.warning(f"The expected stream id {packet[2]} does not match the contained stream id {fcio_stream.config.streamid}")
+
+        any_full = self.decoder.decode_packet(fcio_stream, rbl[0], packet_id)
+
+        return bool(any_full)
+
+
+
+class ORFCIOStatusDecoder(OrcaDecoder):
+    def __init__(self, header: OrcaHeader = None, **kwargs) -> None:
+
+        self.decoder = FCStatusDecoder()
+        self.decoded_values = {}
+        self.key_list = {
+          'status' : [],
+          'fspstatus' : []
+        }
+        self.max_rows_in_packet = 0
+        super().__init__(header=header, **kwargs)
+
+    def set_header(self, header: OrcaHeader) -> None:
+        """Setter for headers. Overload to set card parameters, etc."""
+        self.header = header
+        self.fc_hdr_info = extract_header_information(header)
+        self.decoded_values = copy.deepcopy(self.decoder.get_decoded_values())
+
+        for fcid in self.fc_hdr_info['n_card']:
+            self.key_list['status'] = [get_status_key(fcid, 0)] # we pretent we have a master, if it's not there the
+            self.key_list['status'] += [get_status_key(fcid, 0x2000 + i) for i in range(self.fc_hdr_info['n_card'][fcid])]
+            self.decoded_values[fcid] = copy.deepcopy(self.decoder.get_decoded_values())
+            if self.fc_hdr_info["fsp_enabled"][fcid]:
+                self.key_list['fspstatus'].append(get_key(fcid,0,0))
+                self.fsp_decoder = FSPStatusDecoder()
+        self.max_rows_in_packet = max(self.fc_hdr_info["n_card"].values()) + 1
+
+    def get_key_lists(self) -> list[list[int|str]]:
+        return list(self.key_list.values())
+
+    def get_decoded_values(self, key: int = None) -> dict[str, Any]:
+        if key is None:
+            dec_vals_list = list(self.decoded_values.values())
+            if len(dec_vals_list) > 0:
+                return dec_vals_list[0]
+            raise RuntimeError("decoded_values not built")
+        fcid = get_fcid(key)
+        if fcid * 1e6 == key and self.fsp_decoder is not None:
+            return self.fsp_decoder.get_decoded_values()
+        fcid = get_status_fcid(key)
+        if fcid in self.decoded_values:
+            return self.decoded_values[fcid]
+        raise KeyError(f"no decoded values for key {key} (fcid {fcid})")
+
+    def get_max_rows_in_packet(self) -> int:
+        return self.max_rows_in_packet
+
+    def decode_packet(
+        self, packet: OrcaPacket, packet_id: int, rbl: RawBufferList
+    ) -> bool:
+        status_rbkd = rbl.get_keyed_dict()
+
+        fcio_stream = get_fcio_stream(packet[2])
+        fcio_stream.set_mem_field(memoryview(packet[3:]))
+
+        self.decoder.set_fcio_stream(fcio_stream)
+        self.fsp_decoder.set_fcio_stream(fcio_stream)
+
+        any_full = False
+        while fcio_stream.get_record():
+            if fcio_stream.tag == Tags.Status:
+                any_full |= self.decoder.decode_packet(fcio_stream, status_rbkd, packet_id)
+
+        return bool(any_full)
+
+
+
+class ORFCIOEventHeaderDecoder(OrcaDecoder):
+    def __init__(self, header: OrcaHeader = None, **kwargs) -> None:
+
+        self.decoder = FCEventHeaderDecoder()
+        self.fsp_decoder = None
+        self.decoded_values = {}
+        self.key_list = []
+
+        super().__init__(header=header, **kwargs)
+
+    def set_header(self, header: OrcaHeader) -> None:
+        """Setter for headers. Overload to set card parameters, etc."""
+        self.header = header
+
+        self.fc_hdr_info = extract_header_information(header)
+
+        key_list = self.fc_hdr_info['key_list']
+        for fcid in key_list:
+            self.key_list.append(get_key(fcid,0,0))
+            self.decoded_values[fcid] = copy.deepcopy(self.decoder.get_decoded_values())
+            if self.fc_hdr_info["fsp_enabled"][fcid]:
+                self.fsp_decoder = FSPEventDecoder()
+                self.decoded_values[fcid] |= copy.deepcopy(self.fsp_decoder.get_decoded_values())
+
+        self.max_rows_in_packet = max(self.fc_hdr_info["n_adc"].values())
+
+    def get_key_lists(self) -> list[list[int]]:
+        return [self.key_list]
+
+    def get_decoded_values(self, key: int = None) -> dict[str, Any]:
+        if key is None:
+            dec_vals_list = list(self.decoded_values.values())
+            if len(dec_vals_list) > 0:
+                return dec_vals_list[0]
+            raise RuntimeError("decoded_values not built")
+        fcid = get_fcid(key)
+        # if get_card_address(key) == 0 and get_card_input(key) == 0 and self.fsp_decoder is not None:
+        #     return self.fsp_decoder.get_decoded_values()
+        if fcid in self.decoded_values:
+            return self.decoded_values[fcid]
+            # return self.decoder.get_decoded_values()
+        raise KeyError(f"no decoded values for key {key} (fcid {fcid})")
+
+    def decode_packet(
+        self, packet: OrcaPacket, packet_id: int, rbl: RawBufferList
+    ) -> bool:
+        evthdr_rbkd = rbl.get_keyed_dict()
+        fcio_stream = get_fcio_stream(packet[2])
+        fcio_stream.set_mem_field(memoryview(packet[3:]))
+        self.decoder.set_fcio_stream(fcio_stream)
+        if self.fsp_decoder is not None:
+            self.fsp_decoder.set_fcio_stream(fcio_stream)
+
+        any_full = False
+        while fcio_stream.get_record():
+            if fcio_stream.tag == Tags.EventHeader:
+                any_full |= self.decoder.decode_packet(fcio_stream, evthdr_rbkd, packet_id)
+                if self.fsp_decoder is not None:
+                    any_full |= self.fsp_decoder.decode_packet(fcio_stream, evthdr_rbkd, packet_id)
+
+        return bool(any_full)
+
+
+
+class ORFCIOEventDecoder(OrcaDecoder):
+    """Decoder for FlashCam FCIO stream data written by ORCA."""
+
+    def __init__(self, header: OrcaHeader = None, **kwargs) -> None:
+        self.decoder = FCEventDecoder()
+        self.fsp_decoder = None
+
+        self.key_list = {
+          'event' : [],
+          'fspevent' : []
+        }
+        self.decoded_values = {}
+        self.max_rows_in_packet = 0
+
+        # self.skipped_channels = {}
+        super().__init__(header=header, **kwargs)
+
+    def set_header(self, header: OrcaHeader) -> None:
+        """Setter for headers. Overload to set card parameters, etc."""
+        self.header = header
+        # self.key_list = copy.deepcopy(self.decoder.get_key_lists())
+        self.fc_hdr_info = extract_header_information(header)
+        key_list = self.fc_hdr_info['key_list']
+        for fcid in key_list:
+            self.key_list['event'] += key_list[fcid]
+            self.decoded_values[fcid] = copy.deepcopy(self.decoder.get_decoded_values())
+            self.decoded_values[fcid]["waveform"]["wf_len"] = self.fc_hdr_info["wf_len"][fcid]
+            if self.fc_hdr_info["fsp_enabled"][fcid]:
+                self.key_list['fspevent'].append(get_key(fcid,0,0))
+                self.fsp_decoder = FSPEventDecoder()
+        self.max_rows_in_packet = max(self.fc_hdr_info["n_adc"].values())
+
+    def get_key_lists(self) -> list[list[int]]:
+        return list(self.key_list.values())
+
+    def get_max_rows_in_packet(self) -> int:
+        return self.max_rows_in_packet
+
+    def get_decoded_values(self, key: int = None) -> dict[str, Any]:
+        if key is None:
+            dec_vals_list = list(self.decoded_values.values())
+            if len(dec_vals_list) > 0:
+                return dec_vals_list[0]
+            raise RuntimeError("decoded_values not built")
+        fcid = get_fcid(key)
+        if get_card_address(key) == get_card_input(key) == 0 and self.fsp_decoder is not None:
+            return self.fsp_decoder.get_decoded_values()
+        if fcid in self.decoded_values:
+            return self.decoded_values[fcid]
+        raise KeyError(f"no decoded values for key {key} (fcid {fcid})")
+
+    def decode_packet(
+        self, packet: OrcaPacket, packet_id: int, rbl: RawBufferList
+    ) -> bool:
+        """Decode the ORCA FlashCam ADC packet."""
+        evt_rbkd = rbl.get_keyed_dict()
+
+        fcio_stream = get_fcio_stream(packet[2])
+        fcio_stream.set_mem_field(memoryview(packet[3:]))
+
+        self.decoder.set_fcio_stream(fcio_stream)
+        self.fsp_decoder.set_fcio_stream(fcio_stream)
+
+        any_full = False
+        while fcio_stream.get_record():
+            if fcio_stream.tag == Tags.Event or fcio_stream.tag == Tags.SparseEvent:
+                any_full |= self.decoder.decode_packet(fcio_stream, evt_rbkd, packet_id)
+                if self.fsp_decoder is not None:
+                    any_full |= self.fsp_decoder.decode_packet(fcio_stream, evt_rbkd, packet_id)
+
+        return bool(any_full)

--- a/src/daq2lh5/orca/orca_fcio.py
+++ b/src/daq2lh5/orca/orca_fcio.py
@@ -57,20 +57,12 @@ def extract_header_information(header: OrcaHeader):
         ])
 
 
-    log.debug(f"CardInfoDict")
-    for crate in fc_card_info_dict:
-        for card in fc_card_info_dict[crate]:
-            log.debug(f"crate {crate} card {card} {fc_card_info_dict[crate][card]}")
-
     fc_listener_info_list = header.get_readout_info("ORFlashCamListenerModel")
     for fc_listener_info in fc_listener_info_list:
         fcid = fc_listener_info["uniqueID"] # it should be called listener_id
         if fcid == 0:
             raise ValueError("got fcid=0 unexpectedly!")
         fc_hdr_info["fsp_enabled"][fcid] = header.get_auxhw_info("ORFlashCamListenerModel", fcid)["fspEnabled"]
-
-        # get FC card object info from header to use below
-        # gives access like fc_info[crate][card]
 
         fc_hdr_info["wf_len"][fcid] = header.get_auxhw_info("ORFlashCamListenerModel", fcid)["eventSamples"]
         fc_hdr_info["n_adc"][fcid] = 0
@@ -84,8 +76,6 @@ def extract_header_information(header: OrcaHeader):
             card_address = fc_card_info_dict[crate][card]["CardAddress"]
             fc_hdr_info["adc_card_layout"][fcid][card_address] = (crate, card, card_address)
             fc_hdr_info["n_card"][fcid] += 1
-
-            log.debug(f"fcid {fcid} has crate {crate} card {card} {fc_card_info_dict[crate][card]['Class Name']}")
 
             if crate not in fc_card_info_dict:
                 raise RuntimeError(f"no crate {crate} in fc_card_info_dict")
@@ -114,12 +104,35 @@ class ORFCIOConfigDecoder(OrcaDecoder):
 
         self.decoder = FCConfigDecoder()
         self.decoded_values = {}
+        self.key_list = {
+          'fc_config' : [],
+          'fsp_config' : []
+        }
+        self.max_rows_in_packet = 0
 
         super().__init__(header=header, **kwargs)
 
     def set_header(self, header: OrcaHeader) -> None:
         self.header = header
+        self.fc_hdr_info = extract_header_information(header)
         self.decoded_values = copy.deepcopy(self.decoder.get_decoded_values())
+
+        for fcid in self.fc_hdr_info['fsp_enabled']:
+            key = get_key(fcid, 0, 0)
+            self.key_list['fc_config'].append(key)
+            if self.fc_hdr_info["fsp_enabled"][fcid]:
+                self.fsp_decoder = FSPConfigDecoder()
+                self.key_list['fsp_config'].append(f"fsp_config_{key}")
+        self.max_rows_in_packet = 1
+
+    def get_key_lists(self) -> list[list[int|str]]:
+        return list(self.key_list.values())
+
+    def get_decoded_values(self, key: int | str = None) -> dict[str, Any]:
+        if isinstance(key,str) and key.startswith('fsp_config'):
+            return copy.deepcopy(self.fsp_decoder.get_decoded_values())
+        return self.decoded_values
+        raise KeyError(f"no decoded values for key {key}")
 
     def decode_packet(
         self, packet: OrcaPacket, packet_id: int, rbl: RawBufferList
@@ -135,7 +148,14 @@ class ORFCIOConfigDecoder(OrcaDecoder):
         if fcio_stream.config.streamid != packet[2]:
             log.warning(f"The expected stream id {packet[2]} does not match the contained stream id {fcio_stream.config.streamid}")
 
-        any_full = self.decoder.decode_packet(fcio_stream, rbl[0], packet_id)
+        config_rbkd = rbl.get_keyed_dict()
+
+        # TODO instead of preselecting the rbkd with the key here, let the decoder do it
+        fc_key = get_key(fcio_stream.config.streamid, 0, 0)
+        any_full = self.decoder.decode_packet(fcio_stream, config_rbkd[fc_key], packet_id)
+        if self.fsp_decoder is not None:
+            fsp_key = f"fsp_config_{get_key(fcio_stream.config.streamid, 0, 0)}"
+            any_full |= self.fsp_decoder.decode_packet(fcio_stream, config_rbkd[fsp_key], packet_id)
 
         return bool(any_full)
 
@@ -147,8 +167,8 @@ class ORFCIOStatusDecoder(OrcaDecoder):
         self.decoder = FCStatusDecoder()
         self.decoded_values = {}
         self.key_list = {
-          'status' : [],
-          'fspstatus' : []
+          'fc_status' : [],
+          'fsp_status' : []
         }
         self.max_rows_in_packet = 0
         super().__init__(header=header, **kwargs)
@@ -160,30 +180,34 @@ class ORFCIOStatusDecoder(OrcaDecoder):
         self.decoded_values = copy.deepcopy(self.decoder.get_decoded_values())
 
         for fcid in self.fc_hdr_info['n_card']:
-            self.key_list['status'] = [get_status_key(fcid, 0)] # we pretent we have a master, if it's not there the
-            self.key_list['status'] += [get_status_key(fcid, 0x2000 + i) for i in range(self.fc_hdr_info['n_card'][fcid])]
-            self.decoded_values[fcid] = copy.deepcopy(self.decoder.get_decoded_values())
+            # We expect there always to be a master distribution module
+            # If it's not there, the rb for this key will never be filled
+            # and not appear in the lh5 file.
+            self.key_list['fc_status'] = [get_status_key(fcid, 0)]
+            self.key_list['fc_status'] += [get_status_key(fcid, 0x2000 + i) for i in range(self.fc_hdr_info['n_card'][fcid])]
             if self.fc_hdr_info["fsp_enabled"][fcid]:
-                self.key_list['fspstatus'].append(get_key(fcid,0,0))
+                key = get_key(fcid, 0, 0)
+                self.key_list['fsp_status'].append(f"fsp_status_{key}")
                 self.fsp_decoder = FSPStatusDecoder()
         self.max_rows_in_packet = max(self.fc_hdr_info["n_card"].values()) + 1
 
     def get_key_lists(self) -> list[list[int|str]]:
         return list(self.key_list.values())
 
-    def get_decoded_values(self, key: int = None) -> dict[str, Any]:
+    def get_decoded_values(self, key: int | str = None) -> dict[str, Any]:
         if key is None:
             dec_vals_list = list(self.decoded_values.values())
             if len(dec_vals_list) > 0:
                 return dec_vals_list[0]
             raise RuntimeError("decoded_values not built")
-        fcid = get_fcid(key)
-        if fcid * 1e6 == key and self.fsp_decoder is not None:
-            return self.fsp_decoder.get_decoded_values()
-        fcid = get_status_fcid(key)
-        if fcid in self.decoded_values:
-            return self.decoded_values[fcid]
-        raise KeyError(f"no decoded values for key {key} (fcid {fcid})")
+
+        if isinstance(key, str) and key.startswith("fsp_status") and self.fsp_decoder is not None:
+            return copy.deepcopy(self.fsp_decoder.get_decoded_values())
+        elif isinstance(key, int):
+            return copy.deepcopy(self.decoder.get_decoded_values())
+        else:
+            raise KeyError(f"no decoded values for key {key}")
+
 
     def get_max_rows_in_packet(self) -> int:
         return self.max_rows_in_packet
@@ -203,6 +227,8 @@ class ORFCIOStatusDecoder(OrcaDecoder):
         while fcio_stream.get_record():
             if fcio_stream.tag == Tags.Status:
                 any_full |= self.decoder.decode_packet(fcio_stream, status_rbkd, packet_id)
+                if self.fsp_decoder is not None:
+                    any_full |= self.fsp_decoder.decode_packet(fcio_stream, status_rbkd, packet_id)
 
         return bool(any_full)
 
@@ -214,7 +240,10 @@ class ORFCIOEventHeaderDecoder(OrcaDecoder):
         self.decoder = FCEventHeaderDecoder()
         self.fsp_decoder = None
         self.decoded_values = {}
-        self.key_list = []
+        self.key_list = {
+          'fc_eventheader' : [],
+          'fsp_event' : []
+        }
 
         super().__init__(header=header, **kwargs)
 
@@ -226,30 +255,27 @@ class ORFCIOEventHeaderDecoder(OrcaDecoder):
 
         key_list = self.fc_hdr_info['key_list']
         for fcid in key_list:
-            self.key_list.append(get_key(fcid,0,0))
+            key = get_key(fcid, 0, 0)
+            self.key_list['fc_eventheader'].append(key)
             self.decoded_values[fcid] = copy.deepcopy(self.decoder.get_decoded_values())
             if self.fc_hdr_info["fsp_enabled"][fcid]:
                 self.fsp_decoder = FSPEventDecoder()
-                self.decoded_values[fcid] |= copy.deepcopy(self.fsp_decoder.get_decoded_values())
+                self.key_list['fsp_event'].append(f"fsp_event_{key}")
 
-        self.max_rows_in_packet = max(self.fc_hdr_info["n_adc"].values())
+        self.max_rows_in_packet = 1
 
-    def get_key_lists(self) -> list[list[int]]:
-        return [self.key_list]
+    def get_key_lists(self) -> list[list[int|str]]:
+        return list(self.key_list.values())
 
-    def get_decoded_values(self, key: int = None) -> dict[str, Any]:
-        if key is None:
-            dec_vals_list = list(self.decoded_values.values())
-            if len(dec_vals_list) > 0:
-                return dec_vals_list[0]
-            raise RuntimeError("decoded_values not built")
-        fcid = get_fcid(key)
-        # if get_card_address(key) == 0 and get_card_input(key) == 0 and self.fsp_decoder is not None:
-        #     return self.fsp_decoder.get_decoded_values()
-        if fcid in self.decoded_values:
-            return self.decoded_values[fcid]
-            # return self.decoder.get_decoded_values()
-        raise KeyError(f"no decoded values for key {key} (fcid {fcid})")
+    def get_decoded_values(self, key: int | str = None) -> dict[str, Any]:
+        if isinstance(key, str) and key.startswith("fsp_event") and self.fsp_decoder is not None:
+            return copy.deepcopy(self.fsp_decoder.get_decoded_values())
+        elif isinstance(key, int):
+            fcid = get_fcid(key)
+            if fcid in self.decoded_values:
+              return self.decoded_values[fcid]
+
+        raise KeyError(f"no decoded values for key {key}")
 
     def decode_packet(
         self, packet: OrcaPacket, packet_id: int, rbl: RawBufferList
@@ -281,12 +307,11 @@ class ORFCIOEventDecoder(OrcaDecoder):
 
         self.key_list = {
           'event' : [],
-          'fspevent' : []
+          'fsp_event' : []
         }
         self.decoded_values = {}
         self.max_rows_in_packet = 0
 
-        # self.skipped_channels = {}
         super().__init__(header=header, **kwargs)
 
     def set_header(self, header: OrcaHeader) -> None:
@@ -300,7 +325,8 @@ class ORFCIOEventDecoder(OrcaDecoder):
             self.decoded_values[fcid] = copy.deepcopy(self.decoder.get_decoded_values())
             self.decoded_values[fcid]["waveform"]["wf_len"] = self.fc_hdr_info["wf_len"][fcid]
             if self.fc_hdr_info["fsp_enabled"][fcid]:
-                self.key_list['fspevent'].append(get_key(fcid,0,0))
+                key = get_key(fcid, 0, 0)
+                self.key_list['fsp_event'].append(f"fsp_event_{key}")
                 self.fsp_decoder = FSPEventDecoder()
         self.max_rows_in_packet = max(self.fc_hdr_info["n_adc"].values())
 
@@ -316,12 +342,15 @@ class ORFCIOEventDecoder(OrcaDecoder):
             if len(dec_vals_list) > 0:
                 return dec_vals_list[0]
             raise RuntimeError("decoded_values not built")
-        fcid = get_fcid(key)
-        if get_card_address(key) == get_card_input(key) == 0 and self.fsp_decoder is not None:
-            return self.fsp_decoder.get_decoded_values()
-        if fcid in self.decoded_values:
-            return self.decoded_values[fcid]
-        raise KeyError(f"no decoded values for key {key} (fcid {fcid})")
+
+        if isinstance(key, str) and key.startswith("fsp_event") and self.fsp_decoder is not None:
+            return copy.deepcopy(self.fsp_decoder.get_decoded_values())
+        elif isinstance(key, int):
+            fcid = get_fcid(key)
+            if fcid in self.decoded_values:
+                return self.decoded_values[fcid]
+
+        raise KeyError(f"no decoded values for key {key}")
 
     def decode_packet(
         self, packet: OrcaPacket, packet_id: int, rbl: RawBufferList

--- a/src/daq2lh5/orca/orca_fcio.py
+++ b/src/daq2lh5/orca/orca_fcio.py
@@ -113,6 +113,11 @@ class ORFCIOConfigDecoder(OrcaDecoder):
 
         super().__init__(header=header, **kwargs)
 
+        # The ConfigDecoder is always required for decoding fcio data.
+        # When OrcaStreamer.open_stream is called, we close any open fcio stream
+        for fcio_stream in fcio_stream_library.values():
+            fcio_stream.close()
+
     def set_header(self, header: OrcaHeader) -> None:
         self.header = header
         self.fc_hdr_info = extract_header_information(header)

--- a/src/daq2lh5/orca/orca_flashcam.py
+++ b/src/daq2lh5/orca/orca_flashcam.py
@@ -5,7 +5,7 @@ from typing import Any
 
 import numpy as np
 
-from ..fc.fc_event_decoder import fc_decoded_values
+from ..fc.fc_event_decoder import fc_event_decoded_values
 from ..raw_buffer import RawBufferLibrary
 from .orca_base import OrcaDecoder
 from .orca_header import OrcaHeader
@@ -43,7 +43,7 @@ class ORFlashCamListenerConfigDecoder(OrcaDecoder):
             "packet_len": {"dtype": "uint32"},
             "readout_id": {"dtype": "uint16"},
             "fcid": {"dtype": "uint16"},
-            "telid": {"dtype": "int32"},
+            "streamid": {"dtype": "int32"},
             "nadcs": {"dtype": "int32"},
             "ntriggers": {"dtype": "int32"},
             "nsamples": {"dtype": "int32"},
@@ -458,8 +458,8 @@ class ORFlashCamWaveformDecoder(OrcaDecoder):
 
     def __init__(self, header: OrcaHeader = None, **kwargs) -> None:
         # start with the values defined in fcdaq
-        self.decoded_values_template = copy.deepcopy(fc_decoded_values)
-        """A custom copy of :obj:`.fc.fc_event_decoder.fc_decoded_values`."""
+        self.decoded_values_template = copy.deepcopy(fc_event_decoded_values)
+        """A custom copy of :obj:`.fc.fc_event_decoder.fc_event_decoded_values`."""
         # add header values from Orca
         self.decoded_values_template.update(
             {
@@ -737,6 +737,7 @@ class ORFlashCamWaveformDecoder(OrcaDecoder):
         tbl["waveform"]["values"].nda[ii][:wf_samples] = wf
 
         evt_rbkd[key].loc += 1
+        print(f"-> {tbl["eventnumber"].nda[ii]} {channel} .. {evt_rbkd[key].loc}/{len(evt_rbkd[key])} {id(evt_rbkd[key])} {id(evt_rbkd[key].lgdo)}")
         return evt_rbkd[key].is_full()
 
 

--- a/src/daq2lh5/orca/orca_flashcam.py
+++ b/src/daq2lh5/orca/orca_flashcam.py
@@ -737,7 +737,7 @@ class ORFlashCamWaveformDecoder(OrcaDecoder):
         tbl["waveform"]["values"].nda[ii][:wf_samples] = wf
 
         evt_rbkd[key].loc += 1
-        print(
+        log.info(
             f"-> {tbl['eventnumber'].nda[ii]} {channel} .. {evt_rbkd[key].loc}/{len(evt_rbkd[key])} {id(evt_rbkd[key])} {id(evt_rbkd[key].lgdo)}"
         )
         return evt_rbkd[key].is_full()

--- a/src/daq2lh5/orca/orca_flashcam.py
+++ b/src/daq2lh5/orca/orca_flashcam.py
@@ -737,7 +737,9 @@ class ORFlashCamWaveformDecoder(OrcaDecoder):
         tbl["waveform"]["values"].nda[ii][:wf_samples] = wf
 
         evt_rbkd[key].loc += 1
-        print(f"-> {tbl["eventnumber"].nda[ii]} {channel} .. {evt_rbkd[key].loc}/{len(evt_rbkd[key])} {id(evt_rbkd[key])} {id(evt_rbkd[key].lgdo)}")
+        print(
+            f"-> {tbl["eventnumber"].nda[ii]} {channel} .. {evt_rbkd[key].loc}/{len(evt_rbkd[key])} {id(evt_rbkd[key])} {id(evt_rbkd[key].lgdo)}"
+        )
         return evt_rbkd[key].is_full()
 
 

--- a/src/daq2lh5/orca/orca_flashcam.py
+++ b/src/daq2lh5/orca/orca_flashcam.py
@@ -738,7 +738,7 @@ class ORFlashCamWaveformDecoder(OrcaDecoder):
 
         evt_rbkd[key].loc += 1
         print(
-            f"-> {tbl["eventnumber"].nda[ii]} {channel} .. {evt_rbkd[key].loc}/{len(evt_rbkd[key])} {id(evt_rbkd[key])} {id(evt_rbkd[key].lgdo)}"
+            f"-> {tbl['eventnumber'].nda[ii]} {channel} .. {evt_rbkd[key].loc}/{len(evt_rbkd[key])} {id(evt_rbkd[key])} {id(evt_rbkd[key].lgdo)}"
         )
         return evt_rbkd[key].is_full()
 

--- a/src/daq2lh5/orca/orca_header.py
+++ b/src/daq2lh5/orca/orca_header.py
@@ -46,16 +46,19 @@ class OrcaHeader(dict):
                 return d["Run Control"]["RunNumber"]
         raise ValueError("No run number found in header!")
 
-    def get_object_info(self, orca_class_name: str) -> dict[int, dict[int, dict]]:
+    def get_object_info(self, orca_class_name: str | list[str]) -> dict[int, dict[int, dict]]:
         """Returns a ``dict[crate][card]`` with all info from the header for
         each card with name `orca_class_name`.
         """
         object_info_dict = {}
 
+        if isinstance(orca_class_name,str):
+            orca_class_name = [orca_class_name]
+
         crates = self["ObjectInfo"]["Crates"]
         for crate in crates:
             for card in crate["Cards"]:
-                if card["Class Name"] == orca_class_name:
+                if card["Class Name"] in orca_class_name:
                     if crate["CrateNumber"] not in object_info_dict:
                         object_info_dict[crate["CrateNumber"]] = {}
                     object_info_dict[crate["CrateNumber"]][card["Card"]] = card

--- a/src/daq2lh5/orca/orca_header.py
+++ b/src/daq2lh5/orca/orca_header.py
@@ -46,13 +46,15 @@ class OrcaHeader(dict):
                 return d["Run Control"]["RunNumber"]
         raise ValueError("No run number found in header!")
 
-    def get_object_info(self, orca_class_name: str | list[str]) -> dict[int, dict[int, dict]]:
+    def get_object_info(
+        self, orca_class_name: str | list[str]
+    ) -> dict[int, dict[int, dict]]:
         """Returns a ``dict[crate][card]`` with all info from the header for
         each card with name `orca_class_name`.
         """
         object_info_dict = {}
 
-        if isinstance(orca_class_name,str):
+        if isinstance(orca_class_name, str):
             orca_class_name = [orca_class_name]
 
         crates = self["ObjectInfo"]["Crates"]

--- a/src/daq2lh5/orca/orca_packet.py
+++ b/src/daq2lh5/orca/orca_packet.py
@@ -19,10 +19,18 @@ OrcaPacket = npt.NDArray[np.uint32]
 def is_short(packet: OrcaPacket) -> bool:
     return bool(packet[0] >> 31)
 
+def is_extended(packet: OrcaPacket) -> bool:
+    # if the packet is 0 size in default format
+    # the length if the packet is stored in the next uint32
+    return bool((packet[0] & 0x3FFFF) == 0)
 
 def get_n_words(packet: OrcaPacket) -> int:
     if is_short(packet):
         return 1
+    if is_extended(packet):
+        # we could check here if packet is actually long enough
+        # to return packet[1]
+        return packet[1]
     return packet[0] & 0x3FFFF
 
 

--- a/src/daq2lh5/orca/orca_packet.py
+++ b/src/daq2lh5/orca/orca_packet.py
@@ -19,10 +19,12 @@ OrcaPacket = npt.NDArray[np.uint32]
 def is_short(packet: OrcaPacket) -> bool:
     return bool(packet[0] >> 31)
 
+
 def is_extended(packet: OrcaPacket) -> bool:
     # if the packet is 0 size in default format
     # the length if the packet is stored in the next uint32
     return bool((packet[0] & 0x3FFFF) == 0)
+
 
 def get_n_words(packet: OrcaPacket) -> int:
     if is_short(packet):

--- a/src/daq2lh5/orca/orca_streamer.py
+++ b/src/daq2lh5/orca/orca_streamer.py
@@ -57,9 +57,13 @@ class OrcaStreamer(DataStreamer):
         if n_bytes_read == 0:  # EOF
             return None
         if (n_bytes_read % 4) != 0:
-            raise RuntimeError(f"got {n_bytes_read} bytes for packet header, expect 4 or 8.")
+            raise RuntimeError(
+                f"got {n_bytes_read} bytes for packet header, expect 4 or 8."
+            )
         if orca_packet.is_extended(pkt_hdr) and n_bytes_read < 8:
-            raise RuntimeError(f"got {n_bytes_read} bytes for packet header, but require 8 for the extended header format.")
+            raise RuntimeError(
+                f"got {n_bytes_read} bytes for packet header, but require 8 for the extended header format."
+            )
         if orca_packet.is_short(pkt_hdr) and n_bytes_read > 4:
             # if more than 4 bytes were read but the packet is short, we reset the file stream
             # so we can read the next uint32_t again. would not be necessary with a circular buffer
@@ -101,7 +105,9 @@ class OrcaStreamer(DataStreamer):
             pkt_hdr = self.load_packet_header()
             if pkt_hdr is None:
                 return False
-            self.in_stream.seek((orca_packet.get_n_words(pkt_hdr) - len(pkt_hdr)) * 4, 1)
+            self.in_stream.seek(
+                (orca_packet.get_n_words(pkt_hdr) - len(pkt_hdr)) * 4, 1
+            )
             n -= 1
         return True
 
@@ -194,7 +200,7 @@ class OrcaStreamer(DataStreamer):
         # load into buffer, resizing as necessary
         if len(self.buffer) < n_words:
             self.buffer.resize(n_words, refcheck=False)
-        n_bytes_read = self.in_stream.readinto(self.buffer[len(pkt_hdr):n_words])
+        n_bytes_read = self.in_stream.readinto(self.buffer[len(pkt_hdr) : n_words])
         self.n_bytes_read += n_bytes_read
         if n_bytes_read != (n_words - len(pkt_hdr)) * 4:
             log.error(

--- a/src/daq2lh5/orca/orca_streamer.py
+++ b/src/daq2lh5/orca/orca_streamer.py
@@ -14,6 +14,12 @@ from .orca_digitizers import (  # noqa: F401
     ORSIS3302DecoderForEnergy,
     ORSIS3316WaveformDecoder,
 )
+from .orca_fcio import (  # noqa: F401;
+    ORFCIOConfigDecoder,
+    ORFCIOEventDecoder,
+    ORFCIOEventHeaderDecoder,
+    ORFCIOStatusDecoder,
+)
 from .orca_flashcam import (  # noqa: F401;
     ORFlashCamADCWaveformDecoder,
     ORFlashCamListenerConfigDecoder,

--- a/src/daq2lh5/orca/orca_streamer.py
+++ b/src/daq2lh5/orca/orca_streamer.py
@@ -40,18 +40,24 @@ class OrcaStreamer(DataStreamer):
         self.rbl_id_dict = {}  # dict of RawBufferLists for each data_id
         self.missing_decoders = []
 
-    def load_packet_header(self) -> np.uint32 | None:
+    def load_packet_header(self) -> np.ndarray | None:
         """Loads the packet header at the current read location into the buffer
 
         and updates internal variables.
         """
-        pkt_hdr = self.buffer[:1]
+        pkt_hdr = self.buffer[:2]
         n_bytes_read = self.in_stream.readinto(pkt_hdr)  # buffer is at least 4 kB long
         self.n_bytes_read += n_bytes_read
         if n_bytes_read == 0:  # EOF
             return None
-        if n_bytes_read != 4:
-            raise RuntimeError(f"only got {n_bytes_read} bytes for packet header")
+        if (n_bytes_read % 4) != 0:
+            raise RuntimeError(f"got {n_bytes_read} bytes for packet header, expect 4 or 8.")
+        if orca_packet.is_extended(pkt_hdr) and n_bytes_read < 8:
+            raise RuntimeError(f"got {n_bytes_read} bytes for packet header, but require 8 for the extended header format.")
+        if orca_packet.is_short(pkt_hdr) and n_bytes_read > 4:
+            # if more than 4 bytes were read but the packet is short, we reset the file stream
+            # so we can read the next uint32_t again. would not be necessary with a circular buffer
+            self.in_stream.seek(n_bytes_read - 4, 1)
 
         # packet is valid. Can set the packet_id and log its location
         self.packet_id += 1
@@ -89,7 +95,7 @@ class OrcaStreamer(DataStreamer):
             pkt_hdr = self.load_packet_header()
             if pkt_hdr is None:
                 return False
-            self.in_stream.seek((orca_packet.get_n_words(pkt_hdr) - 1) * 4, 1)
+            self.in_stream.seek((orca_packet.get_n_words(pkt_hdr) - len(pkt_hdr)) * 4, 1)
             n -= 1
         return True
 
@@ -105,14 +111,14 @@ class OrcaStreamer(DataStreamer):
             self.in_stream.seek(loc)
             self.packet_id = pid
 
-    def count_packets(self, saveloc=True) -> None:
+    def count_packets(self, saveloc=True) -> int:
         self.build_packet_locs(saveloc=saveloc)
         return len(self.packet_locs)
 
     # TODO: need to correct for endianness?
     def load_packet(
         self, index: int = None, whence: int = 0, skip_unknown_ids: bool = False
-    ) -> np.uint32 | None:
+    ) -> np.ndarray | None:
         """Loads the next packet into the internal buffer.
 
         Returns packet as a :class:`numpy.uint32` view of the buffer (a slice),
@@ -176,15 +182,15 @@ class OrcaStreamer(DataStreamer):
             and orca_packet.get_data_id(pkt_hdr, shift=False)
             not in self.decoder_id_dict
         ):
-            self.in_stream.seek((n_words - 1) * 4, 1)
+            self.in_stream.seek((n_words - len(pkt_hdr)) * 4, 1)
             return pkt_hdr
 
         # load into buffer, resizing as necessary
         if len(self.buffer) < n_words:
             self.buffer.resize(n_words, refcheck=False)
-        n_bytes_read = self.in_stream.readinto(self.buffer[1:n_words])
+        n_bytes_read = self.in_stream.readinto(self.buffer[len(pkt_hdr):n_words])
         self.n_bytes_read += n_bytes_read
-        if n_bytes_read != (n_words - 1) * 4:
+        if n_bytes_read != (n_words - len(pkt_hdr)) * 4:
             log.error(
                 f"only got {n_bytes_read} bytes for packet read when {(n_words-1)*4} were expected. Flushing all buffers and quitting..."
             )

--- a/src/daq2lh5/raw_buffer.py
+++ b/src/daq2lh5/raw_buffer.py
@@ -67,12 +67,15 @@ keys.
 from __future__ import annotations
 
 import os
+import logging
 
 import lgdo
 from lgdo import LGDO
 from lgdo.lh5 import LH5Store
 
 from .buffer_processor.buffer_processor import buffer_processor
+
+log = logging.getLogger(__name__)
 
 
 class RawBuffer:
@@ -183,6 +186,8 @@ class RawBufferList(list):
             self.keyed_dict = {}
             for rb in self:
                 for key in rb.key_list:
+                    if key in self.keyed_dict:
+                        log.warning(f"Key {key} is duplicate.")
                     self.keyed_dict[key] = rb
         return self.keyed_dict
 

--- a/src/daq2lh5/raw_buffer.py
+++ b/src/daq2lh5/raw_buffer.py
@@ -66,8 +66,8 @@ keys.
 
 from __future__ import annotations
 
-import os
 import logging
+import os
 
 import lgdo
 from lgdo import LGDO

--- a/tests/buffer_processor/test_buffer_processor.py
+++ b/tests/buffer_processor/test_buffer_processor.py
@@ -10,10 +10,10 @@ from lgdo import lh5
 from lgdo.compression import RadwareSigcompress, ULEB128ZigZagDiff
 
 from daq2lh5.build_raw import build_raw
-from daq2lh5.fc.fc_event_decoder import fc_decoded_values
+from daq2lh5.fc.fc_event_decoder import fc_event_decoded_values
 
 # skip waveform compression in build_raw
-fc_decoded_values["waveform"].pop("compression", None)
+fc_event_decoded_values["waveform"].pop("compression", None)
 
 config_dir = Path(__file__).parent / "test_buffer_processor_configs"
 
@@ -71,7 +71,7 @@ def test_buffer_processor_waveform_lengths(lgnd_test_data, tmptestdir):
     out_spec = {
         "FCEventDecoder": {
             "ch{key}": {
-                "key_list": [[0, 6]],
+                "key_list": [[52800, 52806]],
                 "out_stream": processed_file + ":{name}",
                 "out_name": "raw",
                 "proc_spec": {
@@ -105,7 +105,7 @@ def test_buffer_processor_waveform_lengths(lgnd_test_data, tmptestdir):
     copy_out_spec = {
         "FCEventDecoder": {
             "ch{key}": {
-                "key_list": [[0, 6]],
+                "key_list": [[52800, 52806]],
                 "out_stream": raw_file + ":{name}",
                 "out_name": "raw",
             }
@@ -114,7 +114,7 @@ def test_buffer_processor_waveform_lengths(lgnd_test_data, tmptestdir):
 
     build_raw(in_stream=daq_file, out_spec=out_spec, overwrite=True)
 
-    proc_spec = out_spec["FCEventDecoder"]["ch0"].pop("proc_spec")
+    proc_spec = out_spec["FCEventDecoder"]["ch52800"].pop("proc_spec")
     dsp_config = proc_spec["dsp_config"]
     window_config = proc_spec["window"]
 
@@ -298,7 +298,7 @@ def test_buffer_processor_separate_name_tables(lgnd_test_data, tmptestdir):
     out_spec = {
         "FCEventDecoder": {
             "geds": {
-                "key_list": [[0, 3]],
+                "key_list": [[52800, 52803]],
                 "out_stream": processed_file + ":{name}",
                 "out_name": "raw",
                 "proc_spec": {
@@ -327,7 +327,7 @@ def test_buffer_processor_separate_name_tables(lgnd_test_data, tmptestdir):
                 },
             },
             "spms": {
-                "key_list": [[3, 6]],
+                "key_list": [[52803, 52806]],
                 "out_stream": processed_file + ":{name}",
                 "out_name": "raw",
                 "proc_spec": {
@@ -361,12 +361,12 @@ def test_buffer_processor_separate_name_tables(lgnd_test_data, tmptestdir):
     copy_out_spec = {
         "FCEventDecoder": {
             "geds": {
-                "key_list": [[0, 3]],
+                "key_list": [[52800, 52803]],
                 "out_stream": raw_file + ":{name}",
                 "out_name": "raw",
             },
             "spms": {
-                "key_list": [[3, 6]],
+                "key_list": [[52803, 52806]],
                 "out_stream": raw_file + ":{name}",
                 "out_name": "raw",
             },
@@ -494,7 +494,7 @@ def test_proc_geds_no_proc_spms(lgnd_test_data, tmptestdir):
     out_spec = {
         "FCEventDecoder": {
             "geds": {
-                "key_list": [[0, 1]],
+                "key_list": [[52800, 52801]],
                 "out_stream": processed_file + ":{name}",
                 "out_name": "raw",
                 "proc_spec": {
@@ -536,7 +536,7 @@ def test_proc_geds_no_proc_spms(lgnd_test_data, tmptestdir):
                 },
             },
             "spms": {
-                "key_list": [[3, 4]],
+                "key_list": [[52803, 52804]],
                 "out_stream": processed_file + ":{name}",
                 "out_name": "raw",
             },
@@ -546,12 +546,12 @@ def test_proc_geds_no_proc_spms(lgnd_test_data, tmptestdir):
     copy_out_spec = {
         "FCEventDecoder": {
             "geds": {
-                "key_list": [[0, 1]],
+                "key_list": [[52800, 52801]],
                 "out_stream": raw_file + ":{name}",
                 "out_name": "raw",
             },
             "spms": {
-                "key_list": [[3, 4]],
+                "key_list": [[52803, 52804]],
                 "out_stream": raw_file + ":{name}",
                 "out_name": "raw",
             },
@@ -1332,7 +1332,7 @@ def test_buffer_processor_compression_settings(lgnd_test_data, tmptestdir):
     out_spec = {
         "FCEventDecoder": {
             "ch{key}": {
-                "key_list": [[0, 6]],
+                "key_list": [[52800, 52806]],
                 "out_stream": processed_file + ":{name}",
                 "out_name": "raw",
                 "proc_spec": {
@@ -1376,10 +1376,10 @@ def test_buffer_processor_compression_settings(lgnd_test_data, tmptestdir):
 
     sto = lh5.LH5Store()
     presum_wf, _ = sto.read(
-        "/ch0/raw/presummed_waveform/values", processed_file, decompress=False
+        "/ch52800/raw/presummed_waveform/values", processed_file, decompress=False
     )
     window_wf, _ = sto.read(
-        "/ch0/raw/windowed_waveform/values", processed_file, decompress=False
+        "/ch52800/raw/windowed_waveform/values", processed_file, decompress=False
     )
 
     assert isinstance(presum_wf, lgdo.ArrayOfEncodedEqualSizedArrays)

--- a/tests/buffer_processor/test_lh5_buffer_processor.py
+++ b/tests/buffer_processor/test_lh5_buffer_processor.py
@@ -11,10 +11,10 @@ from lgdo import lh5
 
 from daq2lh5.buffer_processor.lh5_buffer_processor import lh5_buffer_processor
 from daq2lh5.build_raw import build_raw
-from daq2lh5.fc.fc_event_decoder import fc_decoded_values
+from daq2lh5.fc.fc_event_decoder import fc_event_decoded_values
 
 # skip waveform compression in build_raw
-fc_decoded_values["waveform"].pop("compression", None)
+fc_event_decoded_values["waveform"].pop("compression", None)
 
 config_dir = Path(__file__).parent / "test_buffer_processor_configs"
 
@@ -65,7 +65,7 @@ def test_lh5_buffer_processor_waveform_lengths(lgnd_test_data):
     out_spec = {
         "FCEventDecoder": {
             "ch{key}": {
-                "key_list": [[0, 6]],
+                "key_list": [[52800, 52806]],
                 "out_stream": processed_file + ":{name}",
                 "out_name": "raw",
                 "proc_spec": {
@@ -98,7 +98,7 @@ def test_lh5_buffer_processor_waveform_lengths(lgnd_test_data):
     copy_out_spec = {
         "FCEventDecoder": {
             "ch{key}": {
-                "key_list": [[0, 6]],
+                "key_list": [[52800, 52806]],
                 "out_stream": raw_file + ":{name}",
                 "out_name": "raw",
             }
@@ -130,7 +130,7 @@ def test_lh5_buffer_processor_waveform_lengths(lgnd_test_data):
     jsonfile = proc_spec
 
     # Read in the presummed rate from the config file to modify the clock rate later
-    presum_rate_string = jsonfile["ch0"]["dsp_config"]["processors"][
+    presum_rate_string = jsonfile["ch52800"]["dsp_config"]["processors"][
         "presum_rate, presummed_waveform"
     ]["args"][3]
     presum_rate_start_idx = presum_rate_string.find("/") + 1
@@ -138,8 +138,8 @@ def test_lh5_buffer_processor_waveform_lengths(lgnd_test_data):
     presum_rate = int(presum_rate_string[presum_rate_start_idx:presum_rate_end_idx])
 
     # This needs to be overwritten with the correct windowing values set in buffer_processor.py
-    window_start_index = jsonfile["ch0"]["window"][1]
-    window_end_index = jsonfile["ch0"]["window"][2]
+    window_start_index = jsonfile["ch52800"]["window"][1]
+    window_end_index = jsonfile["ch52800"]["window"][2]
 
     sto = lh5.LH5Store()
 
@@ -313,12 +313,12 @@ def test_lh5_buffer_processor_separate_name_tables(lgnd_test_data):
     raw_out_spec = {
         "FCEventDecoder": {
             "geds": {
-                "key_list": [[0, 3]],
+                "key_list": [[52800, 52803]],
                 "out_stream": raw_file + ":{name}",
                 "out_name": "raw",
             },
             "spms": {
-                "key_list": [[3, 6]],
+                "key_list": [[52803, 52806]],
                 "out_stream": raw_file + ":{name}",
                 "out_name": "raw",
             },
@@ -328,7 +328,7 @@ def test_lh5_buffer_processor_separate_name_tables(lgnd_test_data):
     proc_out_spec = {
         "FCEventDecoder": {
             "geds": {
-                "key_list": [[0, 3]],
+                "key_list": [[52800, 52803]],
                 "out_stream": processed_file + ":{name}",
                 "out_name": "raw",
                 "proc_spec": {
@@ -356,7 +356,7 @@ def test_lh5_buffer_processor_separate_name_tables(lgnd_test_data):
                 },
             },
             "spms": {
-                "key_list": [[3, 6]],
+                "key_list": [[52803, 52806]],
                 "out_stream": processed_file + ":{name}",
                 "out_name": "raw",
                 "proc_spec": {
@@ -504,12 +504,12 @@ def test_raw_geds_no_proc_spms(lgnd_test_data):
     raw_out_spec = {
         "FCEventDecoder": {
             "geds": {
-                "key_list": [[0, 1]],
+                "key_list": [[52800, 52801]],
                 "out_stream": raw_file + ":{name}",
                 "out_name": "raw",
             },
             "spms": {
-                "key_list": [[3, 4]],
+                "key_list": [[52803, 52804]],
                 "out_stream": raw_file + ":{name}",
                 "out_name": "raw",
             },
@@ -519,7 +519,7 @@ def test_raw_geds_no_proc_spms(lgnd_test_data):
     proc_out_spec = {
         "FCEventDecoder": {
             "geds": {
-                "key_list": [[0, 1]],
+                "key_list": [[52800, 52801]],
                 "out_stream": processed_file + ":{name}",
                 "out_name": "raw",
                 "proc_spec": {
@@ -1068,7 +1068,7 @@ def test_lh5_buffer_processor_hdf5_settings(lgnd_test_data):
     out_spec = {
         "FCEventDecoder": {
             "ch{key}": {
-                "key_list": [[0, 6]],
+                "key_list": [[52800, 52806]],
                 "out_stream": processed_file + ":{name}",
                 "out_name": "raw",
                 "proc_spec": {
@@ -1108,5 +1108,5 @@ def test_lh5_buffer_processor_hdf5_settings(lgnd_test_data):
     build_raw(in_stream=daq_file, out_spec=out_spec, overwrite=True)
 
     with h5py.File(processed_file) as f:
-        assert f["ch0"]["raw"]["presummed_waveform"]["values"].compression == "lzf"
-        assert f["ch0"]["raw"]["presummed_waveform"]["values"].shuffle is False
+        assert f["ch52800"]["raw"]["presummed_waveform"]["values"].compression == "lzf"
+        assert f["ch52800"]["raw"]["presummed_waveform"]["values"].shuffle is False

--- a/tests/configs/fc-out-spec.json
+++ b/tests/configs/fc-out-spec.json
@@ -1,7 +1,7 @@
 {
   "FCEventDecoder": {
     "spms": {
-      "key_list": [[2, 4]],
+      "key_list": [[52800, 52804]],
       "out_stream": "/tmp/L200-comm-20211130-phy-spms.lh5"
     }
   }

--- a/tests/fc/conftest.py
+++ b/tests/fc/conftest.py
@@ -1,4 +1,4 @@
-import fcutils
+import fcio
 import pytest
 
 from daq2lh5.fc.fc_config_decoder import FCConfigDecoder
@@ -6,7 +6,7 @@ from daq2lh5.fc.fc_config_decoder import FCConfigDecoder
 
 @pytest.fixture(scope="module")
 def fcio_obj(lgnd_test_data):
-    return fcutils.fcio(
+    return fcio.fcio_open(
         lgnd_test_data.get_path("fcio/L200-comm-20211130-phy-spms.fcio")
     )
 
@@ -14,5 +14,4 @@ def fcio_obj(lgnd_test_data):
 @pytest.fixture(scope="module")
 def fcio_config(fcio_obj):
     decoder = FCConfigDecoder()
-    decoder.decode_config(fcio_obj)
-    return decoder.config
+    return decoder.decode_config(fcio_obj)

--- a/tests/fc/test_fc_config_decoder.py
+++ b/tests/fc/test_fc_config_decoder.py
@@ -14,7 +14,7 @@ def test_values(fcio_config):
         "nsamples": 6000,
         "nadcs": 6,
         "ntriggers": 0,
-        "telid": 0,
+        "streamid": 0,
         "adcbits": 16,
         "sumlength": 1,
         "blprecision": 1,

--- a/tests/fc/test_fc_config_decoder.py
+++ b/tests/fc/test_fc_config_decoder.py
@@ -29,5 +29,8 @@ def test_values(fcio_config):
         assert fcio_config[k].value == v
 
     assert np.array_equal(
-        fcio_config["tracemap"].nda, np.array([34603008,34603009,34603010,34603011,34603012,34603013], dtype='uint32')
+        fcio_config["tracemap"].nda,
+        np.array(
+            [34603008, 34603009, 34603010, 34603011, 34603012, 34603013], dtype="uint32"
+        ),
     )

--- a/tests/fc/test_fc_config_decoder.py
+++ b/tests/fc/test_fc_config_decoder.py
@@ -1,4 +1,5 @@
 import lgdo
+import numpy as np
 
 
 def test_decoding(fcio_config):
@@ -26,3 +27,7 @@ def test_values(fcio_config):
 
     for k, v in expected_dict.items():
         assert fcio_config[k].value == v
+
+    assert np.array_equal(
+        fcio_config["tracemap"].nda, np.array([34603008,34603009,34603010,34603011,34603012,34603013], dtype='uint32')
+    )

--- a/tests/fc/test_fc_event_decoder.py
+++ b/tests/fc/test_fc_event_decoder.py
@@ -75,7 +75,11 @@ def test_data_types(event_rbkd):
 def test_values(event_rbkd, fcio_obj):
     fc = fcio_obj
     for ii, ch in enumerate(fc.event.trace_list):
-        key = get_key(fc.config.streamid, fc.config.tracemap[ch] >> 16, fc.config.tracemap[ch] & 0xFFFF)
+        key = get_key(
+            fc.config.streamid,
+            fc.config.tracemap[ch] >> 16,
+            fc.config.tracemap[ch] & 0xFFFF,
+        )
         loc = event_rbkd[key].loc - 1
         tbl = event_rbkd[key].lgdo
 

--- a/tests/fc/test_fc_event_decoder.py
+++ b/tests/fc/test_fc_event_decoder.py
@@ -48,7 +48,6 @@ def test_data_types(event_rbkd):
         assert isinstance(tbl["lifetime"], lgdo.Array)
         assert isinstance(tbl["deadtime"], lgdo.Array)
         assert isinstance(tbl["numtraces"], lgdo.Array)
-        # assert isinstance(tbl["tracelist"], lgdo.VectorOfVectors)
         assert isinstance(tbl["baseline"], lgdo.Array)
         assert isinstance(tbl["daqenergy"], lgdo.Array)
         assert isinstance(tbl["channel"], lgdo.Array)
@@ -67,7 +66,6 @@ def test_data_types(event_rbkd):
         assert isinstance(tbl["dr_stop_pps"], lgdo.Array)
         assert isinstance(tbl["dr_stop_ticks"], lgdo.Array)
         assert isinstance(tbl["dr_maxticks"], lgdo.Array)
-        # assert isinstance(tbl["deadtime_nsec"], lgdo.Array)
         assert isinstance(tbl["waveform"], lgdo.Struct)
         assert isinstance(tbl["waveform"]["t0"], lgdo.Array)
         assert isinstance(tbl["waveform"]["dt"], lgdo.Array)
@@ -90,14 +88,6 @@ def test_values(event_rbkd, fcio_obj):
         assert tbl["lifetime"].nda[loc] == fc.event.life_time_sec[ii]
         assert tbl["deadtime"].nda[loc] == fc.event.dead_time_sec[ii]
         assert tbl["numtraces"].nda[loc] == fc.event.num_traces
-
-        # custom logic for VectorOfVectors
-        # start = 0 if loc == 0 else tbl["tracelist"].cumulative_length.nda[loc - 1]
-        # stop = start + len(fc.event.trace_list)
-        # assert np.array_equal(
-        #     tbl["tracelist"].flattened_data.nda[start:stop], fc.event.trace_list
-        # )
-
         assert tbl["baseline"].nda[loc], fc.event.fpga_baseline[ii]
         assert tbl["daqenergy"].nda[loc], fc.event.fpga_energy[ii]
         assert tbl["channel"].nda[loc] == ch

--- a/tests/fc/test_fc_event_decoder.py
+++ b/tests/fc/test_fc_event_decoder.py
@@ -1,25 +1,27 @@
 import lgdo
 import numpy as np
 import pytest
+from fcio import Tags as FCIOTag
 
-from daq2lh5.fc.fc_event_decoder import FCEventDecoder
+from daq2lh5.fc.fc_event_decoder import FCEventDecoder, get_key
 from daq2lh5.raw_buffer import RawBuffer
 
 
 @pytest.fixture(scope="module")
-def event_rbkd(fcio_obj, fcio_config):
+def event_rbkd(fcio_obj):
     decoder = FCEventDecoder()
-    decoder.set_file_config(fcio_config)
+    decoder.set_fcio_stream(fcio_obj)
 
     # get just one record and check if it's a (sparse) event
-    assert fcio_obj.get_record() == 3 or fcio_obj.get_record() == 6
+    assert fcio_obj.get_record()
+    assert fcio_obj.tag == FCIOTag.Event or fcio_obj.tag == FCIOTag.SparseEvent
 
     # build raw buffer for each channel in the FC trace list
     rbkd = {}
-    for i in fcio_obj.tracelist:
-        nadcs = decoder.get_max_rows_in_packet()
-        rbkd[i] = RawBuffer(lgdo=decoder.make_lgdo(size=nadcs))
-        rbkd[i].fill_safety = nadcs
+    for i in fcio_obj.event.trace_list:
+        key = decoder.key_list[i]
+        rbkd[key] = RawBuffer(lgdo=decoder.make_lgdo(key=key, size=1))
+        rbkd[key].fill_safety = 1
 
     # decode packet into the lgdo's and check if the buffer is full
     assert decoder.decode_packet(fcio=fcio_obj, evt_rbkd=rbkd, packet_id=69) is True
@@ -43,8 +45,10 @@ def test_data_types(event_rbkd):
         assert isinstance(tbl["eventnumber"], lgdo.Array)
         assert isinstance(tbl["timestamp"], lgdo.Array)
         assert isinstance(tbl["runtime"], lgdo.Array)
+        assert isinstance(tbl["lifetime"], lgdo.Array)
+        assert isinstance(tbl["deadtime"], lgdo.Array)
         assert isinstance(tbl["numtraces"], lgdo.Array)
-        assert isinstance(tbl["tracelist"], lgdo.VectorOfVectors)
+        # assert isinstance(tbl["tracelist"], lgdo.VectorOfVectors)
         assert isinstance(tbl["baseline"], lgdo.Array)
         assert isinstance(tbl["daqenergy"], lgdo.Array)
         assert isinstance(tbl["channel"], lgdo.Array)
@@ -63,7 +67,7 @@ def test_data_types(event_rbkd):
         assert isinstance(tbl["dr_stop_pps"], lgdo.Array)
         assert isinstance(tbl["dr_stop_ticks"], lgdo.Array)
         assert isinstance(tbl["dr_maxticks"], lgdo.Array)
-        assert isinstance(tbl["deadtime"], lgdo.Array)
+        # assert isinstance(tbl["deadtime_nsec"], lgdo.Array)
         assert isinstance(tbl["waveform"], lgdo.Struct)
         assert isinstance(tbl["waveform"]["t0"], lgdo.Array)
         assert isinstance(tbl["waveform"]["dt"], lgdo.Array)
@@ -72,44 +76,52 @@ def test_data_types(event_rbkd):
 
 def test_values(event_rbkd, fcio_obj):
     fc = fcio_obj
-    for ch in fc.tracelist:
-        loc = event_rbkd[ch].loc - 1
-        tbl = event_rbkd[ch].lgdo
+    for ii, ch in enumerate(fc.event.trace_list):
+        key = get_key(fc.config.streamid, fc.config.tracemap[ch] >> 16, fc.config.tracemap[ch] & 0xFFFF)
+        loc = event_rbkd[key].loc - 1
+        tbl = event_rbkd[key].lgdo
 
-        assert event_rbkd[ch].fill_safety >= fc.numtraces
+        assert event_rbkd[key].fill_safety == 1
 
         assert tbl["packet_id"].nda[loc] == 69
-        assert tbl["eventnumber"].nda[loc] == fc.eventnumber
-        assert tbl["timestamp"].nda[loc] == fc.eventtime
-        assert tbl["runtime"].nda[loc] == fc.runtime
-        assert tbl["numtraces"].nda[loc] == fc.numtraces
+        assert tbl["eventnumber"].nda[loc] == fc.event.timestamp[0]
+        assert tbl["timestamp"].nda[loc] == fc.event.unix_time_utc_sec
+        assert tbl["runtime"].nda[loc] == fc.event.run_time_sec[ii]
+        assert tbl["lifetime"].nda[loc] == fc.event.life_time_sec[ii]
+        assert tbl["deadtime"].nda[loc] == fc.event.dead_time_sec[ii]
+        assert tbl["numtraces"].nda[loc] == fc.event.num_traces
 
         # custom logic for VectorOfVectors
-        start = 0 if loc == 0 else tbl["tracelist"].cumulative_length.nda[loc - 1]
-        stop = start + len(fc.tracelist)
-        assert np.array_equal(
-            tbl["tracelist"].flattened_data.nda[start:stop], fc.tracelist
-        )
+        # start = 0 if loc == 0 else tbl["tracelist"].cumulative_length.nda[loc - 1]
+        # stop = start + len(fc.event.trace_list)
+        # assert np.array_equal(
+        #     tbl["tracelist"].flattened_data.nda[start:stop], fc.event.trace_list
+        # )
 
-        assert np.array_equal(tbl["baseline"].nda[loc], fc.baseline[ch])
-        assert np.array_equal(tbl["daqenergy"].nda[loc], fc.daqenergy[ch])
+        assert tbl["baseline"].nda[loc], fc.event.fpga_baseline[ii]
+        assert tbl["daqenergy"].nda[loc], fc.event.fpga_energy[ii]
         assert tbl["channel"].nda[loc] == ch
-        assert tbl["ts_pps"].nda[loc] == fc.timestamp_pps
-        assert tbl["ts_ticks"].nda[loc] == fc.timestamp_ticks
-        assert tbl["ts_maxticks"].nda[loc] == fc.timestamp_maxticks
-        assert tbl["mu_offset_sec"].nda[loc] == fc.timeoffset_mu_sec
-        assert tbl["mu_offset_usec"].nda[loc] == fc.timeoffset_mu_usec
-        assert tbl["to_master_sec"].nda[loc] == fc.timeoffset_master_sec
-        assert tbl["delta_mu_usec"].nda[loc] == fc.timeoffset_dt_mu_usec
-        assert tbl["abs_delta_mu_usec"].nda[loc] == fc.timeoffset_abs_mu_usec
-        assert tbl["to_start_sec"].nda[loc] == fc.timeoffset_start_sec
-        assert tbl["to_start_usec"].nda[loc] == fc.timeoffset_start_usec
-        assert tbl["dr_start_pps"].nda[loc] == fc.deadregion_start_pps
-        assert tbl["dr_start_ticks"].nda[loc] == fc.deadregion_start_ticks
-        assert tbl["dr_stop_pps"].nda[loc] == fc.deadregion_stop_pps
-        assert tbl["dr_stop_ticks"].nda[loc] == fc.deadregion_stop_ticks
-        assert tbl["dr_maxticks"].nda[loc] == fc.deadregion_maxticks
-        assert tbl["deadtime"].nda[loc] == fc.deadtime
+        assert tbl["ts_pps"].nda[loc] == fc.event.timestamp[1]
+        assert tbl["ts_ticks"].nda[loc] == fc.event.timestamp[2]
+        assert tbl["ts_maxticks"].nda[loc] == fc.event.timestamp[3]
+        assert tbl["mu_offset_sec"].nda[loc] == fc.event.timeoffset[0]
+        assert tbl["mu_offset_usec"].nda[loc] == fc.event.timeoffset[1]
+        assert tbl["to_master_sec"].nda[loc] == fc.event.timeoffset[2]
+        assert tbl["delta_mu_usec"].nda[loc] == fc.event.timeoffset[3]
+        assert tbl["abs_delta_mu_usec"].nda[loc] == fc.event.timeoffset[4]
+        assert tbl["to_start_sec"].nda[loc] == fc.event.timeoffset[5]
+        assert tbl["to_start_usec"].nda[loc] == fc.event.timeoffset[6]
+        assert tbl["dr_start_pps"].nda[loc] == fc.event.deadregion[0]
+        assert tbl["dr_start_ticks"].nda[loc] == fc.event.deadregion[1]
+        assert tbl["dr_stop_pps"].nda[loc] == fc.event.deadregion[2]
+        assert tbl["dr_stop_ticks"].nda[loc] == fc.event.deadregion[3]
+        assert tbl["dr_maxticks"].nda[loc] == fc.event.deadregion[4]
+        if fc.event.deadregion_size == 7:
+            assert tbl["dr_ch_idx"].nda[loc] == fc.event.deadregion[5]
+            assert tbl["dr_ch_len"].nda[loc] == fc.event.deadregion[6]
+        else:
+            assert tbl["dr_ch_idx"].nda[loc] == 0
+            assert tbl["dr_ch_len"].nda[loc] == fc.config.adcs
         assert tbl["waveform"]["t0"].nda[loc] == 0
-        assert tbl["waveform"]["dt"].nda[loc] == 16
-        assert np.array_equal(tbl["waveform"]["values"].nda[loc], fc.traces[ch])
+        assert tbl["waveform"]["dt"].nda[loc] == fc.config.sampling_period_ns
+        assert np.array_equal(tbl["waveform"]["values"].nda[loc], fc.event.trace[ii])

--- a/tests/fc/test_fc_status_decoder.py
+++ b/tests/fc/test_fc_status_decoder.py
@@ -119,7 +119,3 @@ def test_values(status_rbkd, fcio_obj):
         assert np.array_equal(
             tbl["link_states"].flattened_data.nda[start:stop], card_data.linkstates
         )
-
-        # assert np.array_equal(tbl["adc_temps"].nda[loc], card_data.daughterboard_temperatures_mC)
-        # assert np.array_equal(tbl["cti_links"].nda[loc], card_data.ctilinks)
-        # assert np.array_equal(tbl["link_states"].nda[loc], card_data.linkstates)

--- a/tests/fc/test_fc_status_decoder.py
+++ b/tests/fc/test_fc_status_decoder.py
@@ -1,4 +1,3 @@
-
 import lgdo
 import numpy as np
 import pytest

--- a/tests/fc/test_fc_status_decoder.py
+++ b/tests/fc/test_fc_status_decoder.py
@@ -24,8 +24,6 @@ def status_rbkd(fcio_obj):
 
     ncards = decoder.get_max_rows_in_packet()
 
-    print(ncards)
-
     assert ncards == fcio_obj.status.cards
 
     # build raw buffer for each channel in the FC trace list

--- a/tests/fc/test_fc_status_decoder.py
+++ b/tests/fc/test_fc_status_decoder.py
@@ -1,9 +1,8 @@
-from multiprocessing.dummy import Array
 
 import lgdo
-from fcio import Tags as FCIOTag
 import numpy as np
 import pytest
+from fcio import Tags as FCIOTag
 from pytest import approx
 
 from daq2lh5.fc.fc_status_decoder import FCStatusDecoder, get_key
@@ -16,7 +15,7 @@ def status_rbkd(fcio_obj):
     decoder.set_fcio_stream(fcio_obj)
 
     # get first FCIOStatus record
-    nrecords = 1 # first FCIOConfig is decoded automatically
+    nrecords = 1  # first FCIOConfig is decoded automatically
     while fcio_obj.get_record():
         nrecords += 1
         if fcio_obj.tag == FCIOTag.Status:
@@ -74,6 +73,7 @@ def test_data_types(status_rbkd):
         assert isinstance(tbl["cti_links"], lgdo.VectorOfVectors)
         assert isinstance(tbl["link_states"], lgdo.VectorOfVectors)
 
+
 def test_values(status_rbkd, fcio_obj):
     for card_data in fcio_obj.status.data:
         key = get_key(fcio_obj.config.streamid, card_data.reqid)
@@ -86,7 +86,9 @@ def test_values(status_rbkd, fcio_obj):
         assert tbl["status"].nda[loc] == fcio_obj.status.status
         assert tbl["fpga_time"].nda[loc] == approx(fcio_obj.status.fpga_time_sec)
         assert tbl["server_time"].nda[loc] == approx(fcio_obj.status.unix_time_utc_sec)
-        assert tbl["fpga_start_time"].nda[loc] == approx(fcio_obj.status.fpga_start_time_sec)
+        assert tbl["fpga_start_time"].nda[loc] == approx(
+            fcio_obj.status.fpga_start_time_sec
+        )
 
         # per card information
         assert tbl["id"].nda[loc] == card_data.reqid
@@ -96,8 +98,12 @@ def test_values(status_rbkd, fcio_obj):
         assert tbl["n_environment_errors"].nda[loc] == card_data.enverrors
         assert tbl["n_cti_errors"].nda[loc] == card_data.ctierrors
         assert np.array_equal(tbl["n_other_errors"].nda[loc], card_data.othererrors)
-        assert np.array_equal(tbl["mb_temps"].nda[loc], card_data.mainboard_temperatures_mC)
-        assert np.array_equal(tbl["mb_voltages"].nda[loc], card_data.mainboard_voltages_mV)
+        assert np.array_equal(
+            tbl["mb_temps"].nda[loc], card_data.mainboard_temperatures_mC
+        )
+        assert np.array_equal(
+            tbl["mb_voltages"].nda[loc], card_data.mainboard_voltages_mV
+        )
         assert tbl["mb_current"].nda[loc] == card_data.mainboard_current_mA
         assert tbl["mb_humidity"].nda[loc] == card_data.mainboard_humiditiy_permille
 
@@ -105,7 +111,8 @@ def test_values(status_rbkd, fcio_obj):
         start = 0 if loc == 0 else tbl["adc_temps"].cumulative_length.nda[loc - 1]
         stop = start + len(card_data.daughterboard_temperatures_mC)
         assert np.array_equal(
-            tbl["adc_temps"].flattened_data.nda[start:stop], card_data.daughterboard_temperatures_mC
+            tbl["adc_temps"].flattened_data.nda[start:stop],
+            card_data.daughterboard_temperatures_mC,
         )
 
         start = 0 if loc == 0 else tbl["ct_links"].cumulative_length.nda[loc - 1]

--- a/tests/fc/test_fc_streamer.py
+++ b/tests/fc/test_fc_streamer.py
@@ -60,10 +60,11 @@ def test_read_packet(lgnd_test_data):
     init_rbytes = streamer.n_bytes_read
     assert streamer.read_packet() is True  # read was successful
     assert streamer.packet_id == 1  # packet id is incremented
-    assert streamer.n_bytes_read == 72384
-    # assert streamer.n_bytes_read == init_rbytes + 144 + 2 * streamer.fcio.event.num_traces * (
-    #     streamer.fcio.config.eventsamples + 2
-    # )
+    traces_nbytes = (
+        2 * streamer.fcio.event.num_traces * (streamer.fcio.config.eventsamples + 2)
+    )
+    header_bytes = 180
+    assert streamer.n_bytes_read == init_rbytes + header_bytes + traces_nbytes
 
 
 def test_read_packet_partial(lgnd_test_data):
@@ -84,10 +85,11 @@ def test_read_packet_partial(lgnd_test_data):
     init_rbytes = streamer.n_bytes_read
     assert streamer.read_packet() is True  # read was successful
     assert streamer.packet_id == 1  # packet id is incremented
-    assert streamer.n_bytes_read == 72384
-    # assert streamer.n_bytes_read == init_rbytes + 144 + 2 * streamer.fcio.event.num_traces * (
-    #     streamer.fcio.config.eventsamples + 2
-    # )
+    traces_nbytes = (
+        2 * streamer.fcio.event.num_traces * (streamer.fcio.config.eventsamples + 2)
+    )
+    header_bytes = 180
+    assert streamer.n_bytes_read == init_rbytes + header_bytes + traces_nbytes
 
 
 def test_read_chunk(lgnd_test_data):

--- a/tests/fc/test_fc_streamer.py
+++ b/tests/fc/test_fc_streamer.py
@@ -1,5 +1,6 @@
 from daq2lh5.fc.fc_config_decoder import FCConfigDecoder
 from daq2lh5.fc.fc_event_decoder import FCEventDecoder
+from daq2lh5.fc.fc_eventheader_decoder import FCEventHeaderDecoder
 from daq2lh5.fc.fc_status_decoder import FCStatusDecoder
 from daq2lh5.fc.fc_streamer import FCStreamer
 from daq2lh5.raw_buffer import RawBuffer, RawBufferList
@@ -10,6 +11,7 @@ def test_get_decoder_list():
     assert isinstance(streamer.get_decoder_list()[0], FCConfigDecoder)
     assert isinstance(streamer.get_decoder_list()[1], FCStatusDecoder)
     assert isinstance(streamer.get_decoder_list()[2], FCEventDecoder)
+    assert isinstance(streamer.get_decoder_list()[3], FCEventHeaderDecoder)
 
 
 def test_default_rb_lib(lgnd_test_data):
@@ -21,10 +23,19 @@ def test_default_rb_lib(lgnd_test_data):
     assert "FCConfigDecoder" in rb_lib.keys()
     assert "FCStatusDecoder" in rb_lib.keys()
     assert "FCEventDecoder" in rb_lib.keys()
+    assert "FCEventHeaderDecoder" in rb_lib.keys()
+    assert "FSPConfigDecoder" in rb_lib.keys()
+    assert "FSPEventDecoder" in rb_lib.keys()
+    assert "FSPStatusDecoder" in rb_lib.keys()
     assert rb_lib["FCConfigDecoder"][0].out_name == "FCConfig"
     assert rb_lib["FCStatusDecoder"][0].out_name == "FCStatus"
+    assert rb_lib["FCStatusDecoder"][0].key_list == [0, 8192]
     assert rb_lib["FCEventDecoder"][0].out_name == "FCEvent"
-    assert rb_lib["FCEventDecoder"][0].key_list == list(range(0, 6))
+    assert rb_lib["FCEventDecoder"][0].key_list == [ 52800 + _ for _ in range(0, 6) ]
+    assert rb_lib["FCEventHeaderDecoder"][0].out_name == "FCEventHeader"
+    assert rb_lib["FSPConfigDecoder"][0].out_name == "FSPConfig"
+    assert rb_lib["FSPEventDecoder"][0].out_name == "FSPEvent"
+    assert rb_lib["FSPStatusDecoder"][0].out_name == "FSPStatus"
 
 
 def test_open_stream(lgnd_test_data):
@@ -35,7 +46,9 @@ def test_open_stream(lgnd_test_data):
     assert isinstance(res[0], RawBuffer)
     assert streamer.fcio is not None  # fcio object is instantiated
     assert streamer.packet_id == 0  # packet id is initialized
-    assert streamer.n_bytes_read == 11 * 4  # fc header is read
+    assert streamer.n_bytes_read == 180  # fc header is read,
+                                         # includes the stream identifier, and config records
+                                         # depends on the file
     assert streamer.event_rbkd is not None  # dict containing event info is initialized
 
 
@@ -47,9 +60,10 @@ def test_read_packet(lgnd_test_data):
     init_rbytes = streamer.n_bytes_read
     assert streamer.read_packet() is True  # read was successful
     assert streamer.packet_id == 1  # packet id is incremented
-    assert streamer.n_bytes_read == init_rbytes + 144 + 2 * streamer.fcio.numtraces * (
-        streamer.fcio.nsamples + 3
-    )
+    assert streamer.n_bytes_read == 72384
+    # assert streamer.n_bytes_read == init_rbytes + 144 + 2 * streamer.fcio.event.num_traces * (
+    #     streamer.fcio.config.eventsamples + 2
+    # )
 
 
 def test_read_packet_partial(lgnd_test_data):
@@ -70,9 +84,10 @@ def test_read_packet_partial(lgnd_test_data):
     init_rbytes = streamer.n_bytes_read
     assert streamer.read_packet() is True  # read was successful
     assert streamer.packet_id == 1  # packet id is incremented
-    assert streamer.n_bytes_read == init_rbytes + 144 + 2 * streamer.fcio.numtraces * (
-        streamer.fcio.nsamples + 3
-    )
+    assert streamer.n_bytes_read == 72384
+    # assert streamer.n_bytes_read == init_rbytes + 144 + 2 * streamer.fcio.event.num_traces * (
+    #     streamer.fcio.config.eventsamples + 2
+    # )
 
 
 def test_read_chunk(lgnd_test_data):

--- a/tests/fc/test_fc_streamer.py
+++ b/tests/fc/test_fc_streamer.py
@@ -31,7 +31,7 @@ def test_default_rb_lib(lgnd_test_data):
     assert rb_lib["FCStatusDecoder"][0].out_name == "FCStatus"
     assert rb_lib["FCStatusDecoder"][0].key_list == [0, 8192]
     assert rb_lib["FCEventDecoder"][0].out_name == "FCEvent"
-    assert rb_lib["FCEventDecoder"][0].key_list == [ 52800 + _ for _ in range(0, 6) ]
+    assert rb_lib["FCEventDecoder"][0].key_list == [52800 + _ for _ in range(0, 6)]
     assert rb_lib["FCEventHeaderDecoder"][0].out_name == "FCEventHeader"
     assert rb_lib["FSPConfigDecoder"][0].out_name == "FSPConfig"
     assert rb_lib["FSPEventDecoder"][0].out_name == "FSPEvent"
@@ -47,8 +47,8 @@ def test_open_stream(lgnd_test_data):
     assert streamer.fcio is not None  # fcio object is instantiated
     assert streamer.packet_id == 0  # packet id is initialized
     assert streamer.n_bytes_read == 180  # fc header is read,
-                                         # includes the stream identifier, and config records
-                                         # depends on the file
+    # includes the stream identifier, and config records
+    # depends on the file
     assert streamer.event_rbkd is not None  # dict containing event info is initialized
 
 

--- a/tests/test_build_raw.py
+++ b/tests/test_build_raw.py
@@ -76,13 +76,15 @@ def test_invalid_user_buffer_size(lgnd_test_data, tmptestdir):
 def test_build_raw_fc_out_spec(lgnd_test_data, tmptestdir):
     out_file = f"{tmptestdir}/L200-comm-20211130-phy-spms.lh5"
     out_spec = {
-        "FCEventDecoder": {"spms": {"key_list": [[52802, 52804]], "out_stream": out_file}}
+        "FCEventDecoder": {
+            "spms": {"key_list": [[52802, 52804]], "out_stream": out_file}
+        }
     }
 
     build_raw(
         in_stream=lgnd_test_data.get_path("fcio/L200-comm-20211130-phy-spms.fcio"),
         out_spec=out_spec,
-        n_max=10 * 3, # decode 10 events of 3 channels per record into one table
+        n_max=10 * 3,  # decode 10 events of 3 channels per record into one table
         overwrite=True,
     )
 
@@ -111,7 +113,7 @@ def test_build_raw_fc_channelwise_out_spec(lgnd_test_data, tmptestdir):
     out_spec = {
         "FCEventDecoder": {
             "ch{key}": {
-                "key_list": [[52800, 52806 ]],
+                "key_list": [[52800, 52806]],
                 "out_stream": out_file + ":{name}",
                 "out_name": "raw",
             }
@@ -124,7 +126,14 @@ def test_build_raw_fc_channelwise_out_spec(lgnd_test_data, tmptestdir):
         overwrite=True,
     )
 
-    assert lh5.ls(out_file) == ["ch52800", "ch52801", "ch52802", "ch52803", "ch52804", "ch52805"]
+    assert lh5.ls(out_file) == [
+        "ch52800",
+        "ch52801",
+        "ch52802",
+        "ch52803",
+        "ch52804",
+        "ch52805",
+    ]
     assert lh5.ls(out_file, "ch52800/") == ["ch52800/raw"]
     assert lh5.ls(out_file, "ch52800/raw/waveform") == ["ch52800/raw/waveform"]
 
@@ -220,7 +229,9 @@ def test_build_raw_hdf5_settings_in_decoded_values(lgnd_test_data, tmptestdir):
 def test_build_raw_wf_compression_in_decoded_values(lgnd_test_data, tmptestdir):
     out_file = lgnd_test_data.get_path("orca/fc/L200-comm-20220519-phy-geds.lh5")
 
-    fc_event_decoded_values["waveform"].setdefault("hdf5_settings", {"values": {}, "t0": {}})
+    fc_event_decoded_values["waveform"].setdefault(
+        "hdf5_settings", {"values": {}, "t0": {}}
+    )
     fc_event_decoded_values["waveform"]["hdf5_settings"] = {
         "values": {"shuffle": False, "compression": "lzf"},
         "t0": {"shuffle": True, "compression": None},


### PR DESCRIPTION
Replaces https://github.com/legend-exp/pyfcutils with https://github.com/FlashCam/fcio-py as the decoder backend for the fcio data stream.
- support for more record types, like `FCIOEventHeader`, `FCIOFSPConfig`, `FCIOFSPEvent`, `FCIOFSPStatus` 
- `FCIOEvent` now supports keying & decoding with the `rawid` format
-  `FCIOStatusDecoder` has been implemented and uses keys similar to `FCIOEvent` with `listener_id * 1e6 + reqid` where reqid identifies a card. reqid contains the card type in `0xff00` and the index of this card in `0xff`
- Additional fields - computed from the datastream - are available now. Some are decoded in this PR, like correct `deadtime` and `lifetime` fields, as well as a `deadinterval_nsec` field. For compatibility only the `float64` with `unit : s` are decoded, however `nsec` `int64` would be available.
- The FCIO decoded values dictionary touched in this update carry an additional entry now named `description` which would allow showing them in lh5ls. Could be removed if not wanted. The FSP decoded values will be added if this change will be kept.

Orca will ship FC data using a new dataformat, which wraps all `FCIO` records in orca datapackets:
-  the original datastream going into Orca can now be recovered bit-exact.
- This required an update to the Orca Packet format, namely the size of `FCIOEvent` would have been too large for the 18-bit header section of the first `uint32` of an orca packet which specifies the size of the packet. Orca supports now an extentioned format, which encodes the packet size in the second `uint32`. This extension is flagged by the 18-bit section being zero.
- The new decoders are named like the FCIO decoders with `OR` prepended. Internally all decoders use the `decode_packet` functions of the corresponding FC decoders to decode the data itself.
- Due to internal the internal packet writing logic in multi-threaded applications, the FSP Records (SWT) are packaged in the same packet as the record they match categorically (Config, Status) or which they are derived from (Event). Due the internal reading logic of FCIO these FSP records appear before their corresponding FCIO records in the stream (but are decoded at the same time).

Both changes should result in the same lh5 data format irrespective of the data source (fcio or orca) - as long as the correct out_spec is used. However due to the different packaging (`fc_streamer` parsing each record separately vs `orca_streamer` parsing records as bunched data packets) the out_specs differ in their keying.
Namely the `orca_streamer` doesn't have dedicated `FSP` decoders, but accesses these records via a special key `fsp_{event,config,status}_{rawid}` where `rawid` is only ever `<listenerid> * 1e6`. 
This `rawid` signifies a subsystem level datastream and is also used (in addition to the FSP records) with the `FCIOEventHeader` records which are only written on non-software-triggered records.

Removed fields from the waveform groups:
- `crate` / `slot` - is also stored in the OrcaRunHeader. The new Orca fc dataformt does not ship these anymore
- `tracelist ` - could be restored, but not needed. Can be recovered by counting the `packet_id` fields

Additions to the waveform groups:
- `deadinterval_nsec` - the accumulated deadtime due to full buffers of this channel since the previous trigger
- `dr_ch_idx` /  `dr_ch_len` - housekeeping fields, if a `SparseEvent` is triggered, these fields indicate the channel indices of the channels which were previously affected by deadtime, if there was any.
- `lifetime` - the time since the trigger enable. not the same as the `runtime` which is is the time since the first hardware synchronization (happens before trigger enable).

Additional/Minor Changes:
- `data_streamer` parsing of wildcards now allows using partial wildcards like: `ch1*` and one pure wildcard (`*`, matches last) in `key_list`.  No duplicate key matches are produced per decoder.
- fix `build_raw` using wrong default chunk_mode
- some additional `log.debug` statements
- `RawBuffer` prints warning if `get_keyed_dict` encounters a duplicate key

Future changes which should be tracked with an issue:
- `FCIOConfigDecoder` and `FSPConfigDecoder` have `decode_packet` (used by `orca_streamer` to fill an lgdo) and `decode_config` (used by `fc_streamer` to create an lgdo). `decode_config` should be removed.

Examplary outspecs using in my testing:

[out_spec_fc.json](https://github.com/user-attachments/files/19129168/out_spec_fc.json)
[out_spec_orca.json](https://github.com/user-attachments/files/19129169/out_spec_orca.json)

It would be best if I would also provide an Orca test file with 2 listeners and a tests for orca_fcio.py
