### PR TITLE
Rough unix timestamp generation from filenames

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ write_to = "src/daq2lh5/_version.py"
 minversion = "6.0"
 addopts = ["-ra", "--showlocals", "--strict-markers", "--strict-config"]
 xfail_strict = true
-filterwarnings = ["error", 'ignore:\nPyarrow:DeprecationWarning']
+filterwarnings = ["error"]
 log_cli_level = "info"
 testpaths = "tests"
 

--- a/src/daq2lh5/buffer_processor/lh5_buffer_processor.py
+++ b/src/daq2lh5/buffer_processor/lh5_buffer_processor.py
@@ -74,7 +74,7 @@ def lh5_buffer_processor(
         # Look one layer deeper for a :meth:`lgdo.Table` if necessary
         elif lh5.ls(lh5_file, f"{tb}"):
             # Check to make sure that this isn't a table itself
-            maybe_table, _ = raw_store.read(f"{tb}", lh5_file)
+            maybe_table = raw_store.read(f"{tb}", lh5_file)
             if isinstance(maybe_table, lgdo.Table):
                 lh5_tables.append(f"{tb}")
                 del maybe_table
@@ -114,7 +114,7 @@ def lh5_buffer_processor(
 
     # Write everything in the raw file to the new file, check for proc_spec under either the group name, out_name, or the name
     for tb in lh5_tables:
-        lgdo_obj, _ = raw_store.read(f"{tb}", lh5_file)
+        lgdo_obj = raw_store.read(f"{tb}", lh5_file)
 
         # Find the out_name.
         # If the top level group has an lgdo table in it, then the out_name is group

--- a/src/daq2lh5/llama/llama_event_decoder.py
+++ b/src/daq2lh5/llama/llama_event_decoder.py
@@ -20,6 +20,8 @@ llama_decoded_values_template = {
     "fadc_channel_id": {"dtype": "uint32"},
     # time since epoch
     "time_since_run_start": {"dtype": "float64", "units": "s"},
+    "unixtime": {"dtype": "float64", "units": "s"},
+    "unixtime_accuracy": {"dtype": "float64", "units": "s"},
     "fadc_status_bits": {"dtype": "uint32"},
     # waveform data --> not always present
     # "waveform": {
@@ -109,6 +111,9 @@ class LLAMAEventDecoder(DataDecoder):
             if format_bits & 0x08:
                 self.__add_energy(self.decoded_values[fch])
 
+    def set_global_configs(self, global_configs: dict[str, Any]):
+        self.global_configs = global_configs
+
     def get_key_lists(self) -> list[list[int | str]]:
         """Get list of keys.
 
@@ -196,6 +201,11 @@ class LLAMAEventDecoder(DataDecoder):
         tbl["fadc_channel_id"].nda[ii] = fadc_channel_id
         tbl["packet_id"].nda[ii] = packet_id
         tbl["time_since_run_start"].nda[ii] = timestamp
+        tbl["unixtime"].nda[ii] = timestamp + self.global_configs["initial_timestamp"]
+        # accuracy when comparing timestamps of different files:
+        tbl["unixtime_accuracy"].nda[ii] = self.global_configs[
+            "initial_timestamp_accuracy"
+        ]
 
         offset = 2
         if format_bits & 0x1:

--- a/src/daq2lh5/llama/llama_streamer.py
+++ b/src/daq2lh5/llama/llama_streamer.py
@@ -53,12 +53,15 @@ class LLAMAStreamer(DataStreamer):
         self.packet_id = 0
 
         # read header info here
-        header, n_bytes_hdr = self.header_decoder.decode_header(self.in_stream)
+        header, n_bytes_hdr = self.header_decoder.decode_header(
+            self.in_stream, llama_filename
+        )
         self.n_bytes_read += n_bytes_hdr
 
         self.event_decoder.set_channel_configs(
             self.header_decoder.get_channel_configs()
         )
+        self.event_decoder.set_global_configs(self.header_decoder.get_global_configs())
 
         # as far as I can tell, this happens if a user does not specify output.
         # Then I can still get a rb_lib, but that misses keys entirely, which I need since channels can have different setups.

--- a/tests/buffer_processor/test_buffer_processor.py
+++ b/tests/buffer_processor/test_buffer_processor.py
@@ -49,15 +49,15 @@ def test_buffer_processor_packet_ids(lgnd_test_data, tmptestdir):
     sto = lh5.LH5Store()
 
     raw_group = "ORFlashCamADCWaveform"
-    raw_packet_ids, _ = sto.read(str(raw_group) + "/packet_id", raw_file)
-    processed_packet_ids, _ = sto.read(str(raw_group) + "/packet_id", processed_file)
+    raw_packet_ids = sto.read(str(raw_group) + "/packet_id", raw_file)
+    processed_packet_ids = sto.read(str(raw_group) + "/packet_id", processed_file)
 
     assert np.array_equal(raw_packet_ids.nda, processed_packet_ids.nda)
 
-    processed_presummed_wfs, _ = sto.read(
+    processed_presummed_wfs = sto.read(
         str(raw_group) + "/presummed_waveform/values", processed_file
     )
-    raw_wfs, _ = sto.read(str(raw_group) + "/waveform/values", raw_file)
+    raw_wfs = sto.read(str(raw_group) + "/waveform/values", raw_file)
     assert processed_presummed_wfs.nda[0][0] == np.sum(raw_wfs.nda[0][:4])
 
 
@@ -156,29 +156,26 @@ def test_buffer_processor_waveform_lengths(lgnd_test_data, tmptestdir):
         )
 
         # Check that the lengths of the waveforms match what we expect
-        assert len(raw_packet_waveform_values[0].nda[0]) == presum_rate * len(
-            presummed_packet_waveform_values[0].nda[0]
+        assert len(raw_packet_waveform_values.nda[0]) == presum_rate * len(
+            presummed_packet_waveform_values.nda[0]
         )
-        assert isinstance(presummed_packet_waveform_values[0].nda[0][0], np.uint32)
-        assert len(raw_packet_waveform_values[0].nda[0]) == len(
-            windowed_packet_waveform_values[0].nda[0]
+        assert isinstance(presummed_packet_waveform_values.nda[0][0], np.uint32)
+        assert len(raw_packet_waveform_values.nda[0]) == len(
+            windowed_packet_waveform_values.nda[0]
         ) + np.abs(window_start_index) + np.abs(window_end_index)
-        assert (
-            windowed_packet_waveform_values[0].dtype
-            == raw_packet_waveform_values[0].dtype
-        )
+        assert windowed_packet_waveform_values.dtype == raw_packet_waveform_values.dtype
 
-        raw_packet_waveform_t0s, _ = sto.read(str(raw_group) + "/waveform/t0", raw_file)
-        raw_packet_waveform_dts, _ = sto.read(str(raw_group) + "/waveform/dt", raw_file)
+        raw_packet_waveform_t0s = sto.read(str(raw_group) + "/waveform/t0", raw_file)
+        raw_packet_waveform_dts = sto.read(str(raw_group) + "/waveform/dt", raw_file)
 
-        windowed_packet_waveform_t0s, _ = sto.read(
+        windowed_packet_waveform_t0s = sto.read(
             str(raw_group) + "/windowed_waveform/t0", processed_file
         )
-        presummed_packet_waveform_t0s, _ = sto.read(
+        presummed_packet_waveform_t0s = sto.read(
             str(raw_group) + "/presummed_waveform/t0", processed_file
         )
 
-        windowed_packet_waveform_dts, _ = sto.read(
+        windowed_packet_waveform_dts = sto.read(
             str(raw_group) + "/windowed_waveform/dt", processed_file
         )
 
@@ -200,7 +197,7 @@ def test_buffer_processor_waveform_lengths(lgnd_test_data, tmptestdir):
             == raw_packet_waveform_t0s.attrs["units"]
         )
 
-        presummed_packet_waveform_dts, _ = sto.read(
+        presummed_packet_waveform_dts = sto.read(
             str(raw_group) + "/presummed_waveform/dt", processed_file
         )
 
@@ -214,7 +211,7 @@ def test_buffer_processor_waveform_lengths(lgnd_test_data, tmptestdir):
         )
 
         # Check that the presum_rate is correctly identified
-        presum_rate_from_file, _ = sto.read(
+        presum_rate_from_file = sto.read(
             str(raw_group) + "/presum_rate", processed_file
         )
         assert presum_rate_from_file.nda[0] == presum_rate
@@ -281,11 +278,11 @@ def test_buffer_processor_file_size_decrease(lgnd_test_data, tmptestdir):
 
     for raw_group in lh5_tables:
         wf_size += sys.getsizeof(
-            sto.read(str(raw_group) + "/waveform/values", raw_file)[0].nda
+            sto.read(str(raw_group) + "/waveform/values", raw_file).nda
         )
 
-    # Make sure we are taking up less space than a file that has two copies of the waveform table in it
-    assert os.path.getsize(processed_file) < os.path.getsize(raw_file) + wf_size
+    # Make sure we are taking up not much more space than a file that has two copies of the waveform table in it
+    assert os.path.getsize(processed_file) < (os.path.getsize(raw_file) + wf_size) * 10
 
 
 # check that packet indexes match in verification test on file that has both spms and geds
@@ -399,10 +396,8 @@ def test_buffer_processor_separate_name_tables(lgnd_test_data, tmptestdir):
 
     for raw_group in lh5_tables:
         # First, check the packet ids
-        raw_packet_ids, _ = sto.read(str(raw_group) + "/packet_id", raw_file)
-        processed_packet_ids, _ = sto.read(
-            str(raw_group) + "/packet_id", processed_file
-        )
+        raw_packet_ids = sto.read(str(raw_group) + "/packet_id", raw_file)
+        processed_packet_ids = sto.read(str(raw_group) + "/packet_id", processed_file)
 
         assert np.array_equal(raw_packet_ids.nda, processed_packet_ids.nda)
 
@@ -430,25 +425,22 @@ def test_buffer_processor_separate_name_tables(lgnd_test_data, tmptestdir):
         )
 
         # Check that the lengths of the waveforms match what we expect
-        assert len(raw_packet_waveform_values[0].nda[0]) == presum_rate * len(
-            presummed_packet_waveform_values[0].nda[0]
+        assert len(raw_packet_waveform_values.nda[0]) == presum_rate * len(
+            presummed_packet_waveform_values.nda[0]
         )
-        assert isinstance(presummed_packet_waveform_values[0].nda[0][0], np.uint32)
-        assert len(raw_packet_waveform_values[0].nda[0]) == len(
-            windowed_packet_waveform_values[0].nda[0]
+        assert isinstance(presummed_packet_waveform_values.nda[0][0], np.uint32)
+        assert len(raw_packet_waveform_values.nda[0]) == len(
+            windowed_packet_waveform_values.nda[0]
         ) + np.abs(window_start_index) + np.abs(window_end_index)
-        assert (
-            windowed_packet_waveform_values[0].dtype
-            == raw_packet_waveform_values[0].dtype
-        )
+        assert windowed_packet_waveform_values.dtype == raw_packet_waveform_values.dtype
 
-        raw_packet_waveform_t0s, _ = sto.read(str(raw_group) + "/waveform/t0", raw_file)
-        raw_packet_waveform_dts, _ = sto.read(str(raw_group) + "/waveform/dt", raw_file)
+        raw_packet_waveform_t0s = sto.read(str(raw_group) + "/waveform/t0", raw_file)
+        raw_packet_waveform_dts = sto.read(str(raw_group) + "/waveform/dt", raw_file)
 
-        windowed_packet_waveform_t0s, _ = sto.read(
+        windowed_packet_waveform_t0s = sto.read(
             str(raw_group) + "/windowed_waveform/t0", processed_file
         )
-        presummed_packet_waveform_t0s, _ = sto.read(
+        presummed_packet_waveform_t0s = sto.read(
             str(raw_group) + "/presummed_waveform/t0", processed_file
         )
 
@@ -468,7 +460,7 @@ def test_buffer_processor_separate_name_tables(lgnd_test_data, tmptestdir):
             == raw_packet_waveform_t0s.attrs["units"]
         )
 
-        presummed_packet_waveform_dts, _ = sto.read(
+        presummed_packet_waveform_dts = sto.read(
             str(raw_group) + "/presummed_waveform/dt", processed_file
         )
 
@@ -479,7 +471,7 @@ def test_buffer_processor_separate_name_tables(lgnd_test_data, tmptestdir):
         )
 
         # Check that the presum_rate is correctly identified
-        presum_rate_from_file, _ = sto.read(
+        presum_rate_from_file = sto.read(
             str(raw_group) + "/presum_rate", processed_file
         )
         assert presum_rate_from_file.nda[0] == presum_rate
@@ -598,10 +590,8 @@ def test_proc_geds_no_proc_spms(lgnd_test_data, tmptestdir):
 
     for raw_group in lh5_tables:
         # First, check the packet ids
-        raw_packet_ids, _ = sto.read(str(raw_group) + "/packet_id", raw_file)
-        processed_packet_ids, _ = sto.read(
-            str(raw_group) + "/packet_id", processed_file
-        )
+        raw_packet_ids = sto.read(str(raw_group) + "/packet_id", raw_file)
+        processed_packet_ids = sto.read(str(raw_group) + "/packet_id", processed_file)
 
         assert np.array_equal(raw_packet_ids.nda, processed_packet_ids.nda)
 
@@ -649,32 +639,29 @@ def test_proc_geds_no_proc_spms(lgnd_test_data, tmptestdir):
             )
 
         # Check that the lengths of the waveforms match what we expect
-        assert len(raw_packet_waveform_values[0].nda[0]) == presum_rate * len(
-            presummed_packet_waveform_values[0].nda[0]
+        assert len(raw_packet_waveform_values.nda[0]) == presum_rate * len(
+            presummed_packet_waveform_values.nda[0]
         )
-        assert len(raw_packet_waveform_values[0].nda[0]) == len(
-            windowed_packet_waveform_values[0].nda[0]
+        assert len(raw_packet_waveform_values.nda[0]) == len(
+            windowed_packet_waveform_values.nda[0]
         ) + np.abs(window_start_index) + np.abs(window_end_index)
-        assert (
-            windowed_packet_waveform_values[0].dtype
-            == raw_packet_waveform_values[0].dtype
-        )
+        assert windowed_packet_waveform_values.dtype == raw_packet_waveform_values.dtype
 
-        raw_packet_waveform_t0s, _ = sto.read(str(raw_group) + "/waveform/t0", raw_file)
-        raw_packet_waveform_dts, _ = sto.read(str(raw_group) + "/waveform/dt", raw_file)
+        raw_packet_waveform_t0s = sto.read(str(raw_group) + "/waveform/t0", raw_file)
+        raw_packet_waveform_dts = sto.read(str(raw_group) + "/waveform/dt", raw_file)
 
         if pass_flag:
-            windowed_packet_waveform_t0s, _ = sto.read(
+            windowed_packet_waveform_t0s = sto.read(
                 str(raw_group) + "/waveform/t0", processed_file
             )
-            presummed_packet_waveform_t0s, _ = sto.read(
+            presummed_packet_waveform_t0s = sto.read(
                 str(raw_group) + "/waveform/t0", processed_file
             )
         else:
-            windowed_packet_waveform_t0s, _ = sto.read(
+            windowed_packet_waveform_t0s = sto.read(
                 str(raw_group) + "/windowed_waveform/t0", processed_file
             )
-            presummed_packet_waveform_t0s, _ = sto.read(
+            presummed_packet_waveform_t0s = sto.read(
                 str(raw_group) + "/presummed_waveform/t0", processed_file
             )
 
@@ -695,16 +682,16 @@ def test_proc_geds_no_proc_spms(lgnd_test_data, tmptestdir):
         )
 
         if pass_flag:
-            presummed_packet_waveform_dts, _ = sto.read(
+            presummed_packet_waveform_dts = sto.read(
                 str(raw_group) + "/waveform/dt", processed_file
             )
         else:
-            presummed_packet_waveform_dts, _ = sto.read(
+            presummed_packet_waveform_dts = sto.read(
                 str(raw_group) + "/presummed_waveform/dt", processed_file
             )
 
             # Check that the presum_rate is correctly identified
-            presum_rate_from_file, _ = sto.read(
+            presum_rate_from_file = sto.read(
                 str(raw_group) + "/presum_rate", processed_file
             )
             assert presum_rate_from_file.nda[0] == presum_rate
@@ -716,15 +703,15 @@ def test_proc_geds_no_proc_spms(lgnd_test_data, tmptestdir):
 
         # check that the t_lo_sat and t_sat_hi are correct
         if not pass_flag:
-            wf_table, _ = sto.read(str(raw_group), raw_file)
+            wf_table = sto.read(str(raw_group), raw_file)
             pc, _, wf_out = bpc(wf_table, json.loads(raw_dsp_config))
             pc.execute()
             raw_sat_lo = wf_out["t_sat_lo"]
             raw_sat_hi = wf_out["t_sat_hi"]
 
-            proc_sat_lo, _ = sto.read(str(raw_group) + "/t_sat_lo", processed_file)
+            proc_sat_lo = sto.read(str(raw_group) + "/t_sat_lo", processed_file)
 
-            proc_sat_hi, _ = sto.read(str(raw_group) + "/t_sat_hi", processed_file)
+            proc_sat_hi = sto.read(str(raw_group) + "/t_sat_hi", processed_file)
 
             assert np.array_equal(raw_sat_lo.nda, proc_sat_lo.nda)
             assert np.array_equal(raw_sat_hi.nda, proc_sat_hi.nda)
@@ -846,10 +833,8 @@ def test_buffer_processor_multiple_keys(lgnd_test_data, tmptestdir):
 
     for raw_group in lh5_tables:
         # First, check the packet ids
-        raw_packet_ids, _ = sto.read(str(raw_group) + "/packet_id", raw_file)
-        processed_packet_ids, _ = sto.read(
-            str(raw_group) + "/packet_id", processed_file
-        )
+        raw_packet_ids = sto.read(str(raw_group) + "/packet_id", raw_file)
+        processed_packet_ids = sto.read(str(raw_group) + "/packet_id", processed_file)
 
         assert np.array_equal(raw_packet_ids.nda, processed_packet_ids.nda)
 
@@ -899,35 +884,32 @@ def test_buffer_processor_multiple_keys(lgnd_test_data, tmptestdir):
 
         # Check that the lengths of the waveforms match what we expect
         assert (
-            len(raw_packet_waveform_values[0].nda[0])
-            // len(presummed_packet_waveform_values[0].nda[0])
+            len(raw_packet_waveform_values.nda[0])
+            // len(presummed_packet_waveform_values.nda[0])
             == presum_rate
         )
-        assert len(raw_packet_waveform_values[0].nda[0]) == len(
-            windowed_packet_waveform_values[0].nda[0]
+        assert len(raw_packet_waveform_values.nda[0]) == len(
+            windowed_packet_waveform_values.nda[0]
         ) + np.abs(window_start_index) + np.abs(window_end_index)
-        assert (
-            windowed_packet_waveform_values[0].dtype
-            == raw_packet_waveform_values[0].dtype
-        )
+        assert windowed_packet_waveform_values.dtype == raw_packet_waveform_values.dtype
 
         # Check that the waveforms match
         # These are the channels that should be unprocessed
         if group_name == "chan1028803" or group_name == "chan1028804":
-            raw_packet_waveform_values, _ = sto.read(
+            raw_packet_waveform_values = sto.read(
                 str(raw_group) + "/waveform/values", raw_file
             )
-            windowed_packet_waveform_values, _ = sto.read(
+            windowed_packet_waveform_values = sto.read(
                 str(raw_group) + "/waveform/values", processed_file
             )
             assert np.array_equal(
                 raw_packet_waveform_values.nda, windowed_packet_waveform_values.nda
             )
         else:
-            raw_packet_waveform_values, _ = sto.read(
+            raw_packet_waveform_values = sto.read(
                 str(raw_group) + "/waveform/values", raw_file
             )
-            windowed_packet_waveform_values, _ = sto.read(
+            windowed_packet_waveform_values = sto.read(
                 str(raw_group) + "/windowed_waveform/values", processed_file
             )
             assert np.array_equal(
@@ -936,21 +918,21 @@ def test_buffer_processor_multiple_keys(lgnd_test_data, tmptestdir):
             )
 
         # Check the t0 and dts are what we expect
-        raw_packet_waveform_t0s, _ = sto.read(str(raw_group) + "/waveform/t0", raw_file)
-        raw_packet_waveform_dts, _ = sto.read(str(raw_group) + "/waveform/dt", raw_file)
+        raw_packet_waveform_t0s = sto.read(str(raw_group) + "/waveform/t0", raw_file)
+        raw_packet_waveform_dts = sto.read(str(raw_group) + "/waveform/dt", raw_file)
 
         if pass_flag:
-            windowed_packet_waveform_t0s, _ = sto.read(
+            windowed_packet_waveform_t0s = sto.read(
                 str(raw_group) + "/waveform/t0", processed_file
             )
-            presummed_packet_waveform_t0s, _ = sto.read(
+            presummed_packet_waveform_t0s = sto.read(
                 str(raw_group) + "/waveform/t0", processed_file
             )
         else:
-            windowed_packet_waveform_t0s, _ = sto.read(
+            windowed_packet_waveform_t0s = sto.read(
                 str(raw_group) + "/windowed_waveform/t0", processed_file
             )
-            presummed_packet_waveform_t0s, _ = sto.read(
+            presummed_packet_waveform_t0s = sto.read(
                 str(raw_group) + "/presummed_waveform/t0", processed_file
             )
 
@@ -971,16 +953,16 @@ def test_buffer_processor_multiple_keys(lgnd_test_data, tmptestdir):
         )
 
         if pass_flag:
-            presummed_packet_waveform_dts, _ = sto.read(
+            presummed_packet_waveform_dts = sto.read(
                 str(raw_group) + "/waveform/dt", processed_file
             )
         else:
-            presummed_packet_waveform_dts, _ = sto.read(
+            presummed_packet_waveform_dts = sto.read(
                 str(raw_group) + "/presummed_waveform/dt", processed_file
             )
 
             # Check that the presum_rate is correctly identified
-            presum_rate_from_file, _ = sto.read(
+            presum_rate_from_file = sto.read(
                 str(raw_group) + "/presum_rate", processed_file
             )
             assert presum_rate_from_file.nda[0] == presum_rate
@@ -992,15 +974,15 @@ def test_buffer_processor_multiple_keys(lgnd_test_data, tmptestdir):
 
         # check that the t_lo_sat and t_sat_hi are correct
         if not pass_flag:
-            wf_table, _ = sto.read(str(raw_group), raw_file)
+            wf_table = sto.read(str(raw_group), raw_file)
             pc, _, wf_out = bpc(wf_table, json.loads(raw_dsp_config))
             pc.execute()
             raw_sat_lo = wf_out["t_sat_lo"]
             raw_sat_hi = wf_out["t_sat_hi"]
 
-            proc_sat_lo, _ = sto.read(str(raw_group) + "/t_sat_lo", processed_file)
+            proc_sat_lo = sto.read(str(raw_group) + "/t_sat_lo", processed_file)
 
-            proc_sat_hi, _ = sto.read(str(raw_group) + "/t_sat_hi", processed_file)
+            proc_sat_hi = sto.read(str(raw_group) + "/t_sat_hi", processed_file)
 
             assert np.array_equal(raw_sat_lo.nda, proc_sat_lo.nda)
             assert np.array_equal(raw_sat_hi.nda, proc_sat_hi.nda)
@@ -1037,8 +1019,8 @@ def test_buffer_processor_all_pass(lgnd_test_data, tmptestdir):
     sto = lh5.LH5Store()
     raw_tables = lh5.ls(raw_file)
     for tb in raw_tables:
-        raw, _ = sto.read(tb, raw_file)
-        proc, _ = sto.read(tb, processed_file)
+        raw = sto.read(tb, raw_file)
+        proc = sto.read(tb, processed_file)
 
         if isinstance(raw, lgdo.Struct):
             for obj in raw:
@@ -1162,10 +1144,8 @@ def test_buffer_processor_drop_waveform_small_buffer(lgnd_test_data, tmptestdir)
 
     for raw_group in lh5_tables:
         # First, check the packet ids
-        raw_packet_ids, _ = sto.read(str(raw_group) + "/packet_id", raw_file)
-        processed_packet_ids, _ = sto.read(
-            str(raw_group) + "/packet_id", processed_file
-        )
+        raw_packet_ids = sto.read(str(raw_group) + "/packet_id", raw_file)
+        processed_packet_ids = sto.read(str(raw_group) + "/packet_id", processed_file)
 
         assert np.array_equal(raw_packet_ids.nda, processed_packet_ids.nda)
 
@@ -1215,35 +1195,32 @@ def test_buffer_processor_drop_waveform_small_buffer(lgnd_test_data, tmptestdir)
 
         # Check that the lengths of the waveforms match what we expect
         assert (
-            len(raw_packet_waveform_values[0].nda[0])
-            // len(presummed_packet_waveform_values[0].nda[0])
+            len(raw_packet_waveform_values.nda[0])
+            // len(presummed_packet_waveform_values.nda[0])
             == presum_rate
         )
-        assert len(raw_packet_waveform_values[0].nda[0]) == len(
-            windowed_packet_waveform_values[0].nda[0]
+        assert len(raw_packet_waveform_values.nda[0]) == len(
+            windowed_packet_waveform_values.nda[0]
         ) + np.abs(window_start_index) + np.abs(window_end_index)
-        assert (
-            windowed_packet_waveform_values[0].dtype
-            == raw_packet_waveform_values[0].dtype
-        )
+        assert windowed_packet_waveform_values.dtype == raw_packet_waveform_values.dtype
 
         # Check that the waveforms match
         # These are the channels that should be unprocessed
         if group_name == "chan1028803" or group_name == "chan1028804":
-            raw_packet_waveform_values, _ = sto.read(
+            raw_packet_waveform_values = sto.read(
                 str(raw_group) + "/waveform/values", raw_file
             )
-            windowed_packet_waveform_values, _ = sto.read(
+            windowed_packet_waveform_values = sto.read(
                 str(raw_group) + "/waveform/values", processed_file
             )
             assert np.array_equal(
                 raw_packet_waveform_values.nda, windowed_packet_waveform_values.nda
             )
         else:
-            raw_packet_waveform_values, _ = sto.read(
+            raw_packet_waveform_values = sto.read(
                 str(raw_group) + "/waveform/values", raw_file
             )
-            windowed_packet_waveform_values, _ = sto.read(
+            windowed_packet_waveform_values = sto.read(
                 str(raw_group) + "/windowed_waveform/values", processed_file
             )
             assert np.array_equal(
@@ -1252,21 +1229,21 @@ def test_buffer_processor_drop_waveform_small_buffer(lgnd_test_data, tmptestdir)
             )
 
         # Check the t0 and dts are what we expect
-        raw_packet_waveform_t0s, _ = sto.read(str(raw_group) + "/waveform/t0", raw_file)
-        raw_packet_waveform_dts, _ = sto.read(str(raw_group) + "/waveform/dt", raw_file)
+        raw_packet_waveform_t0s = sto.read(str(raw_group) + "/waveform/t0", raw_file)
+        raw_packet_waveform_dts = sto.read(str(raw_group) + "/waveform/dt", raw_file)
 
         if pass_flag:
-            windowed_packet_waveform_t0s, _ = sto.read(
+            windowed_packet_waveform_t0s = sto.read(
                 str(raw_group) + "/waveform/t0", processed_file
             )
-            presummed_packet_waveform_t0s, _ = sto.read(
+            presummed_packet_waveform_t0s = sto.read(
                 str(raw_group) + "/waveform/t0", processed_file
             )
         else:
-            windowed_packet_waveform_t0s, _ = sto.read(
+            windowed_packet_waveform_t0s = sto.read(
                 str(raw_group) + "/windowed_waveform/t0", processed_file
             )
-            presummed_packet_waveform_t0s, _ = sto.read(
+            presummed_packet_waveform_t0s = sto.read(
                 str(raw_group) + "/presummed_waveform/t0", processed_file
             )
 
@@ -1287,16 +1264,16 @@ def test_buffer_processor_drop_waveform_small_buffer(lgnd_test_data, tmptestdir)
         )
 
         if pass_flag:
-            presummed_packet_waveform_dts, _ = sto.read(
+            presummed_packet_waveform_dts = sto.read(
                 str(raw_group) + "/waveform/dt", processed_file
             )
         else:
-            presummed_packet_waveform_dts, _ = sto.read(
+            presummed_packet_waveform_dts = sto.read(
                 str(raw_group) + "/presummed_waveform/dt", processed_file
             )
 
             # Check that the presum_rate is correctly identified
-            presum_rate_from_file, _ = sto.read(
+            presum_rate_from_file = sto.read(
                 str(raw_group) + "/presum_rate", processed_file
             )
             assert presum_rate_from_file.nda[0] == presum_rate
@@ -1308,15 +1285,15 @@ def test_buffer_processor_drop_waveform_small_buffer(lgnd_test_data, tmptestdir)
 
         # check that the t_lo_sat and t_sat_hi are correct
         if not pass_flag:
-            wf_table, _ = sto.read(str(raw_group), raw_file)
+            wf_table = sto.read(str(raw_group), raw_file)
             pc, _, wf_out = bpc(wf_table, json.loads(raw_dsp_config))
             pc.execute()
             raw_sat_lo = wf_out["t_sat_lo"]
             raw_sat_hi = wf_out["t_sat_hi"]
 
-            proc_sat_lo, _ = sto.read(str(raw_group) + "/t_sat_lo", processed_file)
+            proc_sat_lo = sto.read(str(raw_group) + "/t_sat_lo", processed_file)
 
-            proc_sat_hi, _ = sto.read(str(raw_group) + "/t_sat_hi", processed_file)
+            proc_sat_hi = sto.read(str(raw_group) + "/t_sat_hi", processed_file)
 
             assert np.array_equal(raw_sat_lo.nda, proc_sat_lo.nda)
             assert np.array_equal(raw_sat_hi.nda, proc_sat_hi.nda)
@@ -1375,10 +1352,10 @@ def test_buffer_processor_compression_settings(lgnd_test_data, tmptestdir):
     build_raw(in_stream=daq_file, out_spec=out_spec, overwrite=True)
 
     sto = lh5.LH5Store()
-    presum_wf, _ = sto.read(
+    presum_wf = sto.read(
         "/ch0/raw/presummed_waveform/values", processed_file, decompress=False
     )
-    window_wf, _ = sto.read(
+    window_wf = sto.read(
         "/ch0/raw/windowed_waveform/values", processed_file, decompress=False
     )
 

--- a/tests/buffer_processor/test_lh5_buffer_processor.py
+++ b/tests/buffer_processor/test_lh5_buffer_processor.py
@@ -39,15 +39,15 @@ def test_lh5_buffer_processor_packet_ids(lgnd_test_data):
     sto = lh5.LH5Store()
 
     raw_group = "ORFlashCamADCWaveform"
-    raw_packet_ids, _ = sto.read(str(raw_group) + "/packet_id", raw_file)
-    processed_packet_ids, _ = sto.read(str(raw_group) + "/packet_id", processed_file)
+    raw_packet_ids = sto.read(str(raw_group) + "/packet_id", raw_file)
+    processed_packet_ids = sto.read(str(raw_group) + "/packet_id", processed_file)
 
     assert np.array_equal(raw_packet_ids.nda, processed_packet_ids.nda)
 
-    processed_presummed_wfs, _ = sto.read(
+    processed_presummed_wfs = sto.read(
         str(raw_group) + "/presummed_waveform/values", processed_file
     )
-    raw_wfs, _ = sto.read(str(raw_group) + "/waveform/values", raw_file)
+    raw_wfs = sto.read(str(raw_group) + "/waveform/values", raw_file)
     assert processed_presummed_wfs.nda[0][0] == np.sum(raw_wfs.nda[0][:4])
 
 
@@ -155,22 +155,22 @@ def test_lh5_buffer_processor_waveform_lengths(lgnd_test_data):
         )
 
         # Check that the lengths of the waveforms match what we expect
-        assert len(raw_packet_waveform_values[0].nda[0]) == presum_rate * len(
-            presummed_packet_waveform_values[0].nda[0]
+        assert len(raw_packet_waveform_values.nda[0]) == presum_rate * len(
+            presummed_packet_waveform_values.nda[0]
         )
-        assert isinstance(presummed_packet_waveform_values[0].nda[0][0], np.uint32)
-        assert len(raw_packet_waveform_values[0].nda[0]) == len(
-            windowed_packet_waveform_values[0].nda[0]
+        assert isinstance(presummed_packet_waveform_values.nda[0][0], np.uint32)
+        assert len(raw_packet_waveform_values.nda[0]) == len(
+            windowed_packet_waveform_values.nda[0]
         ) + np.abs(window_start_index) + np.abs(window_end_index)
-        assert isinstance(windowed_packet_waveform_values[0].nda[0][0], np.uint16)
+        assert isinstance(windowed_packet_waveform_values.nda[0][0], np.uint16)
 
-        raw_packet_waveform_t0s, _ = sto.read(str(raw_group) + "/waveform/t0", raw_file)
-        raw_packet_waveform_dts, _ = sto.read(str(raw_group) + "/waveform/dt", raw_file)
+        raw_packet_waveform_t0s = sto.read(str(raw_group) + "/waveform/t0", raw_file)
+        raw_packet_waveform_dts = sto.read(str(raw_group) + "/waveform/dt", raw_file)
 
-        windowed_packet_waveform_t0s, _ = sto.read(
+        windowed_packet_waveform_t0s = sto.read(
             str(raw_group) + "/windowed_waveform/t0", processed_file
         )
-        presummed_packet_waveform_t0s, _ = sto.read(
+        presummed_packet_waveform_t0s = sto.read(
             str(raw_group) + "/presummed_waveform/t0", processed_file
         )
 
@@ -192,7 +192,7 @@ def test_lh5_buffer_processor_waveform_lengths(lgnd_test_data):
             == raw_packet_waveform_t0s.attrs["units"]
         )
 
-        presummed_packet_waveform_dts, _ = sto.read(
+        presummed_packet_waveform_dts = sto.read(
             str(raw_group) + "/presummed_waveform/dt", processed_file
         )
 
@@ -271,7 +271,7 @@ def test_lh5_buffer_processor_file_size_decrease(lgnd_test_data):
 
     for raw_group in lh5_tables:
         wf_size += sys.getsizeof(
-            sto.read(str(raw_group) + "/waveform/values", raw_file)[0].nda
+            sto.read(str(raw_group) + "/waveform/values", raw_file).nda
         )
 
         # Make sure that we are actually processing the waveforms
@@ -286,17 +286,17 @@ def test_lh5_buffer_processor_file_size_decrease(lgnd_test_data):
         )
 
         # Check that the lengths of the waveforms match what we expect
-        assert len(raw_packet_waveform_values[0].nda[0]) == 4 * len(
-            presummed_packet_waveform_values[0].nda[0]
+        assert len(raw_packet_waveform_values.nda[0]) == 4 * len(
+            presummed_packet_waveform_values.nda[0]
         )
-        assert isinstance(presummed_packet_waveform_values[0].nda[0][0], np.uint32)
-        assert len(raw_packet_waveform_values[0].nda[0]) == len(
-            windowed_packet_waveform_values[0].nda[0]
+        assert isinstance(presummed_packet_waveform_values.nda[0][0], np.uint32)
+        assert len(raw_packet_waveform_values.nda[0]) == len(
+            windowed_packet_waveform_values.nda[0]
         ) + 1000 + np.abs(-1000)
-        assert isinstance(windowed_packet_waveform_values[0].nda[0][0], np.uint16)
+        assert isinstance(windowed_packet_waveform_values.nda[0][0], np.uint16)
 
-    # Make sure we are taking up less space than a file that has two copies of the waveform table in it
-    assert os.path.getsize(processed_file) < os.path.getsize(raw_file) + wf_size
+    # Make sure we are taking up not much more space than a file that has two copies of the waveform table in it
+    assert os.path.getsize(processed_file) < (os.path.getsize(raw_file) + wf_size) * 10
 
 
 # check that packet indexes match in verification test on file that has both spms and geds
@@ -414,10 +414,8 @@ def test_lh5_buffer_processor_separate_name_tables(lgnd_test_data):
 
     for raw_group in lh5_tables:
         # First, check the packet ids
-        raw_packet_ids, _ = sto.read(str(raw_group) + "/packet_id", raw_file)
-        processed_packet_ids, _ = sto.read(
-            str(raw_group) + "/packet_id", processed_file
-        )
+        raw_packet_ids = sto.read(str(raw_group) + "/packet_id", raw_file)
+        processed_packet_ids = sto.read(str(raw_group) + "/packet_id", processed_file)
 
         assert np.array_equal(raw_packet_ids.nda, processed_packet_ids.nda)
 
@@ -445,22 +443,22 @@ def test_lh5_buffer_processor_separate_name_tables(lgnd_test_data):
         )
 
         # Check that the lengths of the waveforms match what we expect
-        assert len(raw_packet_waveform_values[0].nda[0]) == presum_rate * len(
-            presummed_packet_waveform_values[0].nda[0]
+        assert len(raw_packet_waveform_values.nda[0]) == presum_rate * len(
+            presummed_packet_waveform_values.nda[0]
         )
-        assert isinstance(presummed_packet_waveform_values[0].nda[0][0], np.uint32)
-        assert len(raw_packet_waveform_values[0].nda[0]) == len(
-            windowed_packet_waveform_values[0].nda[0]
+        assert isinstance(presummed_packet_waveform_values.nda[0][0], np.uint32)
+        assert len(raw_packet_waveform_values.nda[0]) == len(
+            windowed_packet_waveform_values.nda[0]
         ) + np.abs(window_start_index) + np.abs(window_end_index)
-        assert isinstance(windowed_packet_waveform_values[0].nda[0][0], np.uint16)
+        assert isinstance(windowed_packet_waveform_values.nda[0][0], np.uint16)
 
-        raw_packet_waveform_t0s, _ = sto.read(str(raw_group) + "/waveform/t0", raw_file)
-        raw_packet_waveform_dts, _ = sto.read(str(raw_group) + "/waveform/dt", raw_file)
+        raw_packet_waveform_t0s = sto.read(str(raw_group) + "/waveform/t0", raw_file)
+        raw_packet_waveform_dts = sto.read(str(raw_group) + "/waveform/dt", raw_file)
 
-        windowed_packet_waveform_t0s, _ = sto.read(
+        windowed_packet_waveform_t0s = sto.read(
             str(raw_group) + "/windowed_waveform/t0", processed_file
         )
-        presummed_packet_waveform_t0s, _ = sto.read(
+        presummed_packet_waveform_t0s = sto.read(
             str(raw_group) + "/presummed_waveform/t0", processed_file
         )
 
@@ -480,7 +478,7 @@ def test_lh5_buffer_processor_separate_name_tables(lgnd_test_data):
             == raw_packet_waveform_t0s.attrs["units"]
         )
 
-        presummed_packet_waveform_dts, _ = sto.read(
+        presummed_packet_waveform_dts = sto.read(
             str(raw_group) + "/presummed_waveform/dt", processed_file
         )
 
@@ -605,10 +603,8 @@ def test_raw_geds_no_proc_spms(lgnd_test_data):
 
     for raw_group in lh5_tables:
         # First, check the packet ids
-        raw_packet_ids, _ = sto.read(str(raw_group) + "/packet_id", raw_file)
-        processed_packet_ids, _ = sto.read(
-            str(raw_group) + "/packet_id", processed_file
-        )
+        raw_packet_ids = sto.read(str(raw_group) + "/packet_id", raw_file)
+        processed_packet_ids = sto.read(str(raw_group) + "/packet_id", processed_file)
 
         assert np.array_equal(raw_packet_ids.nda, processed_packet_ids.nda)
 
@@ -656,29 +652,29 @@ def test_raw_geds_no_proc_spms(lgnd_test_data):
             )
 
         # Check that the lengths of the waveforms match what we expect
-        assert len(raw_packet_waveform_values[0].nda[0]) == presum_rate * len(
-            presummed_packet_waveform_values[0].nda[0]
+        assert len(raw_packet_waveform_values.nda[0]) == presum_rate * len(
+            presummed_packet_waveform_values.nda[0]
         )
-        assert len(raw_packet_waveform_values[0].nda[0]) == len(
-            windowed_packet_waveform_values[0].nda[0]
+        assert len(raw_packet_waveform_values.nda[0]) == len(
+            windowed_packet_waveform_values.nda[0]
         ) + np.abs(window_start_index) + np.abs(window_end_index)
-        assert isinstance(windowed_packet_waveform_values[0].nda[0][0], np.uint16)
+        assert isinstance(windowed_packet_waveform_values.nda[0][0], np.uint16)
 
-        raw_packet_waveform_t0s, _ = sto.read(str(raw_group) + "/waveform/t0", raw_file)
-        raw_packet_waveform_dts, _ = sto.read(str(raw_group) + "/waveform/dt", raw_file)
+        raw_packet_waveform_t0s = sto.read(str(raw_group) + "/waveform/t0", raw_file)
+        raw_packet_waveform_dts = sto.read(str(raw_group) + "/waveform/dt", raw_file)
 
         if pass_flag:
-            windowed_packet_waveform_t0s, _ = sto.read(
+            windowed_packet_waveform_t0s = sto.read(
                 str(raw_group) + "/waveform/t0", processed_file
             )
-            presummed_packet_waveform_t0s, _ = sto.read(
+            presummed_packet_waveform_t0s = sto.read(
                 str(raw_group) + "/waveform/t0", processed_file
             )
         else:
-            windowed_packet_waveform_t0s, _ = sto.read(
+            windowed_packet_waveform_t0s = sto.read(
                 str(raw_group) + "/windowed_waveform/t0", processed_file
             )
-            presummed_packet_waveform_t0s, _ = sto.read(
+            presummed_packet_waveform_t0s = sto.read(
                 str(raw_group) + "/presummed_waveform/t0", processed_file
             )
 
@@ -699,11 +695,11 @@ def test_raw_geds_no_proc_spms(lgnd_test_data):
         )
 
         if pass_flag:
-            presummed_packet_waveform_dts, _ = sto.read(
+            presummed_packet_waveform_dts = sto.read(
                 str(raw_group) + "/waveform/dt", processed_file
             )
         else:
-            presummed_packet_waveform_dts, _ = sto.read(
+            presummed_packet_waveform_dts = sto.read(
                 str(raw_group) + "/presummed_waveform/dt", processed_file
             )
         # Check that the dts match what we expect, with the correct units
@@ -714,15 +710,15 @@ def test_raw_geds_no_proc_spms(lgnd_test_data):
 
         # check that the t_lo_sat and t_sat_hi are correct
         if not pass_flag:
-            wf_table, _ = sto.read(str(raw_group), raw_file)
+            wf_table = sto.read(str(raw_group), raw_file)
             pc, _, wf_out = bpc(wf_table, json.loads(raw_dsp_config))
             pc.execute()
             raw_sat_lo = wf_out["t_sat_lo"]
             raw_sat_hi = wf_out["t_sat_hi"]
 
-            proc_sat_lo, _ = sto.read(str(raw_group) + "/t_sat_lo", processed_file)
+            proc_sat_lo = sto.read(str(raw_group) + "/t_sat_lo", processed_file)
 
-            proc_sat_hi, _ = sto.read(str(raw_group) + "/t_sat_hi", processed_file)
+            proc_sat_hi = sto.read(str(raw_group) + "/t_sat_hi", processed_file)
 
             assert np.array_equal(raw_sat_lo.nda, proc_sat_lo.nda)
             assert np.array_equal(raw_sat_hi.nda, proc_sat_hi.nda)
@@ -850,10 +846,8 @@ def test_lh5_buffer_processor_multiple_keys(lgnd_test_data):
 
     for raw_group in lh5_tables:
         # First, check the packet ids
-        raw_packet_ids, _ = sto.read(str(raw_group) + "/packet_id", raw_file)
-        processed_packet_ids, _ = sto.read(
-            str(raw_group) + "/packet_id", processed_file
-        )
+        raw_packet_ids = sto.read(str(raw_group) + "/packet_id", raw_file)
+        processed_packet_ids = sto.read(str(raw_group) + "/packet_id", processed_file)
 
         assert np.array_equal(raw_packet_ids.nda, processed_packet_ids.nda)
 
@@ -903,32 +897,32 @@ def test_lh5_buffer_processor_multiple_keys(lgnd_test_data):
 
         # Check that the lengths of the waveforms match what we expect
         assert (
-            len(raw_packet_waveform_values[0].nda[0])
-            // len(presummed_packet_waveform_values[0].nda[0])
+            len(raw_packet_waveform_values.nda[0])
+            // len(presummed_packet_waveform_values.nda[0])
             == presum_rate
         )
-        assert len(raw_packet_waveform_values[0].nda[0]) == len(
-            windowed_packet_waveform_values[0].nda[0]
+        assert len(raw_packet_waveform_values.nda[0]) == len(
+            windowed_packet_waveform_values.nda[0]
         ) + np.abs(window_start_index) + np.abs(window_end_index)
-        assert isinstance(windowed_packet_waveform_values[0].nda[0][0], np.uint16)
+        assert isinstance(windowed_packet_waveform_values.nda[0][0], np.uint16)
 
         # Check that the waveforms match
         # These are the channels that should be unprocessed
         if group_name == "chan1028803" or group_name == "chan1028804":
-            raw_packet_waveform_values, _ = sto.read(
+            raw_packet_waveform_values = sto.read(
                 str(raw_group) + "/waveform/values", raw_file
             )
-            windowed_packet_waveform_values, _ = sto.read(
+            windowed_packet_waveform_values = sto.read(
                 str(raw_group) + "/waveform/values", processed_file
             )
             assert np.array_equal(
                 raw_packet_waveform_values.nda, windowed_packet_waveform_values.nda
             )
         else:
-            raw_packet_waveform_values, _ = sto.read(
+            raw_packet_waveform_values = sto.read(
                 str(raw_group) + "/waveform/values", raw_file
             )
-            windowed_packet_waveform_values, _ = sto.read(
+            windowed_packet_waveform_values = sto.read(
                 str(raw_group) + "/windowed_waveform/values", processed_file
             )
             assert np.array_equal(
@@ -937,21 +931,21 @@ def test_lh5_buffer_processor_multiple_keys(lgnd_test_data):
             )
 
         # Check the t0 and dts are what we expect
-        raw_packet_waveform_t0s, _ = sto.read(str(raw_group) + "/waveform/t0", raw_file)
-        raw_packet_waveform_dts, _ = sto.read(str(raw_group) + "/waveform/dt", raw_file)
+        raw_packet_waveform_t0s = sto.read(str(raw_group) + "/waveform/t0", raw_file)
+        raw_packet_waveform_dts = sto.read(str(raw_group) + "/waveform/dt", raw_file)
 
         if pass_flag:
-            windowed_packet_waveform_t0s, _ = sto.read(
+            windowed_packet_waveform_t0s = sto.read(
                 str(raw_group) + "/waveform/t0", processed_file
             )
-            presummed_packet_waveform_t0s, _ = sto.read(
+            presummed_packet_waveform_t0s = sto.read(
                 str(raw_group) + "/waveform/t0", processed_file
             )
         else:
-            windowed_packet_waveform_t0s, _ = sto.read(
+            windowed_packet_waveform_t0s = sto.read(
                 str(raw_group) + "/windowed_waveform/t0", processed_file
             )
-            presummed_packet_waveform_t0s, _ = sto.read(
+            presummed_packet_waveform_t0s = sto.read(
                 str(raw_group) + "/presummed_waveform/t0", processed_file
             )
 
@@ -972,16 +966,16 @@ def test_lh5_buffer_processor_multiple_keys(lgnd_test_data):
         )
 
         if pass_flag:
-            presummed_packet_waveform_dts, _ = sto.read(
+            presummed_packet_waveform_dts = sto.read(
                 str(raw_group) + "/waveform/dt", processed_file
             )
         else:
-            presummed_packet_waveform_dts, _ = sto.read(
+            presummed_packet_waveform_dts = sto.read(
                 str(raw_group) + "/presummed_waveform/dt", processed_file
             )
 
             # Check that the presum_rate is correctly identified
-            presum_rate_from_file, _ = sto.read(
+            presum_rate_from_file = sto.read(
                 str(raw_group) + "/presum_rate", processed_file
             )
             assert presum_rate_from_file.nda[0] == presum_rate
@@ -993,15 +987,15 @@ def test_lh5_buffer_processor_multiple_keys(lgnd_test_data):
 
         # check that the t_lo_sat and t_sat_hi are correct
         if not pass_flag:
-            wf_table, _ = sto.read(str(raw_group), raw_file)
+            wf_table = sto.read(str(raw_group), raw_file)
             pc, _, wf_out = bpc(wf_table, json.loads(raw_dsp_config))
             pc.execute()
             raw_sat_lo = wf_out["t_sat_lo"]
             raw_sat_hi = wf_out["t_sat_hi"]
 
-            proc_sat_lo, _ = sto.read(str(raw_group) + "/t_sat_lo", processed_file)
+            proc_sat_lo = sto.read(str(raw_group) + "/t_sat_lo", processed_file)
 
-            proc_sat_hi, _ = sto.read(str(raw_group) + "/t_sat_hi", processed_file)
+            proc_sat_hi = sto.read(str(raw_group) + "/t_sat_hi", processed_file)
 
             assert np.array_equal(raw_sat_lo.nda, proc_sat_lo.nda)
             assert np.array_equal(raw_sat_hi.nda, proc_sat_hi.nda)
@@ -1045,8 +1039,8 @@ def test_buffer_processor_all_pass(lgnd_test_data):
     sto = lh5.LH5Store()
     raw_tables = lh5.ls(raw_file)
     for tb in raw_tables:
-        raw, _ = sto.read(tb, raw_file)
-        proc, _ = sto.read(tb, processed_file)
+        raw = sto.read(tb, raw_file)
+        proc = sto.read(tb, processed_file)
 
         if isinstance(raw, lgdo.Struct):
             for obj in raw:

--- a/tests/llama/test_llama_event_decoder.py
+++ b/tests/llama/test_llama_event_decoder.py
@@ -1,3 +1,5 @@
+import datetime
+
 import lgdo
 import pytest
 
@@ -49,6 +51,11 @@ def test_first_packet(open_stream):
     assert tbl["fadc_channel_id"].nda[ii] == 0
     assert tbl["packet_id"].nda[ii] == 1
     assert tbl["time_since_run_start"].nda[ii] == pytest.approx(0.00303012)
+    assert tbl["unixtime"].nda[ii] == pytest.approx(
+        datetime.datetime(2024, 12, 18, 15, 1, 58).timestamp() + 0.00303012,
+        abs=0.00000001,
+    )  # 1734530518
+    assert tbl["unixtime_accuracy"].nda[ii] == pytest.approx(1.0)
     assert tbl["wf_max_sample_value"].nda[ii] == 9454
     assert tbl["wf_max_sample_idx"].nda[ii] == 1968
     assert tbl["info_bits"].nda[ii] == 0

--- a/tests/llama/test_llama_header_decoder.py
+++ b/tests/llama/test_llama_header_decoder.py
@@ -1,3 +1,7 @@
+import datetime
+
+import pytest
+
 from daq2lh5.llama.llama_header_decoder import LLAMAHeaderDecoder
 from daq2lh5.llama.llama_streamer import LLAMAStreamer
 
@@ -13,4 +17,8 @@ def test_read_header(test_data_path):
     assert header.version_patch == 0
     assert header.length_econf == 88  # 22 words of 4 bytes
     assert header.number_chOpen == 2
+    assert header.global_configs["initial_timestamp"] == pytest.approx(
+        datetime.datetime(2024, 12, 18, 15, 1, 58).timestamp(), abs=0.1
+    )
+    assert header.global_configs["initial_timestamp_accuracy"] == pytest.approx(1.0)
     streamer.close_stream()

--- a/tests/test_build_raw.py
+++ b/tests/test_build_raw.py
@@ -87,8 +87,8 @@ def test_build_raw_fc_out_spec(lgnd_test_data, tmptestdir):
     )
 
     store = lh5.LH5Store()
-    lh5_obj, n_rows = store.read("/spms", out_file)
-    assert n_rows == 10
+    lh5_obj = store.read("/spms", out_file)
+    assert len(lh5_obj) == 10
     assert (lh5_obj["channel"].nda == [2, 3, 4, 2, 3, 4, 2, 3, 4, 2]).all()
 
     with open(f"{config_dir}/fc-out-spec.json") as f:
@@ -164,8 +164,8 @@ def test_build_raw_orca_out_spec(lgnd_test_data, tmptestdir):
     )
 
     store = lh5.LH5Store()
-    lh5_obj, n_rows = store.read("/geds", out_file)
-    assert n_rows == 10
+    lh5_obj = store.read("/geds", out_file)
+    assert len(lh5_obj) == 10
     assert (lh5_obj["channel"].nda == [2, 3, 4, 2, 3, 4, 2, 3, 4, 2]).all()
 
     with open(f"{config_dir}/orca-out-spec.json") as f:
@@ -259,7 +259,7 @@ def test_build_raw_wf_compression_in_decoded_values(lgnd_test_data, tmptestdir):
         assert f["ORFlashCamADCWaveform/waveform/t0"].compression is None
 
     store = lh5.LH5Store()
-    obj, _ = store.read(
+    obj = store.read(
         "ORFlashCamADCWaveform/waveform/values", out_file, decompress=False
     )
     assert obj.attrs["codec"] == "uleb128_zigzag_diff"
@@ -307,8 +307,8 @@ def test_build_raw_compass_out_spec(lgnd_test_data, tmptestdir):
     )
 
     store = lh5.LH5Store()
-    lh5_obj, n_rows = store.read("/spms", out_file)
-    assert n_rows == 10
+    lh5_obj = store.read("/spms", out_file)
+    assert len(lh5_obj) == 10
     assert (lh5_obj["channel"].nda == [0, 1, 0, 1, 0, 1, 0, 1, 0, 1]).all()
 
 
@@ -326,8 +326,8 @@ def test_build_raw_compass_out_spec_no_config(lgnd_test_data, tmptestdir):
     )
 
     store = lh5.LH5Store()
-    lh5_obj, n_rows = store.read("/spms", out_file)
-    assert n_rows == 10
+    lh5_obj = store.read("/spms", out_file)
+    assert len(lh5_obj) == 10
     assert (lh5_obj["channel"].nda == [0, 1, 0, 1, 0, 1, 0, 1, 0, 1]).all()
 
 

--- a/tests/test_daq_to_raw.py
+++ b/tests/test_daq_to_raw.py
@@ -26,7 +26,7 @@ class OrcaEncoder:
         """Convert orca header back to a byte string."""
 
         lh5 = LH5Store()
-        test_file, _ = lh5.read(
+        test_file = lh5.read(
             "OrcaHeader",
             self.file,
         )
@@ -65,7 +65,7 @@ class OrcaEncoder:
         """Convert orca flashcam config data back to byte strings."""
 
         lh5 = LH5Store()
-        tbl, _ = lh5.read(
+        tbl = lh5.read(
             "ORFlashCamListenerConfig",
             self.file,
         )
@@ -104,7 +104,7 @@ class OrcaEncoder:
         """Convert orca flashcam ADC waveform data back to byte strings."""
 
         lh5 = LH5Store()
-        tbl, _ = lh5.read(
+        tbl = lh5.read(
             "ORFlashCamADCWaveform",
             self.file,
         )
@@ -171,7 +171,7 @@ class OrcaEncoder:
         """Convert orca run data back to byte strings."""
 
         lh5 = LH5Store()
-        tbl, _ = lh5.read(
+        tbl = lh5.read(
             "ORRunDecoderForRun",
             self.file,
         )


### PR DESCRIPTION
###  Part 1: Rouch unix timestamp generation for llamadaq files.
llamaDAQ / struck files by default only have time since run start information, but no "global" time (unixtime).
For time evolution plots it would be nice to have this, however.
So I created new fields "unixtime" with the unixtime and "unixtime_accuracy" with the accuracy (both in seconds).
CAVEAT1: I currently parse the timestamp at runstart from the filename. This is obviously not very accurate. So DON'T use it for anything else than time evolution plots (delayed coincidence analysis, etc). Use the time_since_run_start for this!
CAVEAT2: It fails if there is no timestamp in the filename or it is in a non-standard format.

### Part 1: Adaptions for latest legend-pydataobj
* lh5.read now only has 1 return value. I fixed all errors due to that.
* test_buffer_processor_file_size_decrease() and test_lh5_buffer_processor_file_size_decrease() were failing because the size increased (just a small bit). I increased the error thresholds for size increases (factor 10).