### PR TITLE
Change keys of Orca/FCIO decoders.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ classifiers = [
 requires-python = ">=3.9"
 dependencies = [
     "dspeed>=1.3",
-    "fcio>=0.7.8",
+    "fcio>=0.7.9",
     "h5py>=3.2.0",
     "hdf5plugin",
     "legend-pydataobj>=1.6",

--- a/src/daq2lh5/fc/fc_config_decoder.py
+++ b/src/daq2lh5/fc/fc_config_decoder.py
@@ -66,6 +66,7 @@ class FCConfigDecoder(DataDecoder):
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
         self.decoded_values = copy.deepcopy(fc_config_decoded_values)
+        self.key_list = []
 
     def decode_packet(
         self,
@@ -126,7 +127,12 @@ class FCConfigDecoder(DataDecoder):
         ntraces = fcio.config.adcs + fcio.config.triggers
         tbl.add_field("tracemap", lgdo.Array(fcio.config.tracemap[:ntraces]))
 
+        self.key_list.append(f"fcid_{fcio.config.streamid & 0xFFFF}/config")
+
         return tbl
+
+    def get_key_lists(self) -> list[list[int | str]]:
+        return [copy.deepcopy(self.key_list)]
 
     def get_decoded_values(self, key: int | str = None) -> dict[str, dict[str, Any]]:
         return self.decoded_values

--- a/src/daq2lh5/fc/fc_eventheader_decoder.py
+++ b/src/daq2lh5/fc/fc_eventheader_decoder.py
@@ -212,7 +212,7 @@ class FCEventHeaderDecoder(DataDecoder):
         self.decoded_values["baseline"]["length_guess"] = n_traces
         self.decoded_values["daqenergy"]["length_guess"] = n_traces
 
-        self.key_list = [get_key(fcio_stream.config.streamid, 0, 0)]
+        self.key_list = [f"fcid_{fcio_stream.config.streamid & 0xFFFF}/evt_hdr"]
 
     def get_key_lists(self) -> list[list[int | str]]:
         return [copy.deepcopy(self.key_list)]
@@ -232,7 +232,7 @@ class FCEventHeaderDecoder(DataDecoder):
     ) -> bool:
 
         # only one key available: this streamid
-        key = get_key(fcio.config.streamid, 0, 0)
+        key = f"fcid_{fcio.config.streamid & 0xFFFF}/evt_hdr"
         if key not in evt_hdr_rbkd:
             return False
 

--- a/src/daq2lh5/fc/fc_fsp_decoder.py
+++ b/src/daq2lh5/fc/fc_fsp_decoder.py
@@ -8,7 +8,6 @@ import numpy as np
 from fcio import FCIO, Limits
 
 from ..data_decoder import DataDecoder
-from .fc_eventheader_decoder import get_key
 
 fsp_config_decoded_values = {
     "packet_id": {
@@ -183,7 +182,7 @@ class FSPConfigDecoder(DataDecoder):
         self.key_list = []
 
     def set_fcio_stream(self, fcio_stream: FCIO) -> None:
-        self.key_list = [f"fsp_config_{get_key(fcio_stream.config.streamid, 0, 0)}"]
+        self.key_list = [f"swtid_{fcio_stream.config.streamid & 0xFFFF}/config"]
         if fcio_stream.fsp is not None:
             wps_n_traces = fcio_stream.fsp.config.wps["tracemap"]["n_mapped"]
             hwm_n_traces = fcio_stream.fsp.config.hwm["tracemap"]["n_mapped"]
@@ -694,7 +693,7 @@ class FSPStatusDecoder(DataDecoder):
         self.key_list = []
 
     def set_fcio_stream(self, fcio_stream: FCIO) -> None:
-        self.key_list = [f"fsp_status_{get_key(fcio_stream.config.streamid, 0, 0)}"]
+        self.key_list = [f"swtid_{fcio_stream.config.streamid & 0xFFFF}/status"]
 
     def get_key_lists(self) -> list[list[int | str]]:
         return [copy.deepcopy(self.key_list)]
@@ -709,7 +708,7 @@ class FSPStatusDecoder(DataDecoder):
         packet_id: int,
     ) -> bool:
 
-        key = f"fsp_status_{get_key(fcio.config.streamid, 0, 0)}"
+        key = f"swtid_{fcio.config.streamid & 0xFFFF}/status"
         if key not in fsp_status_rbkd:
             return False
         fsp_status_rb = fsp_status_rbkd[key]
@@ -796,8 +795,8 @@ class FSPEventDecoder(DataDecoder):
     def set_fcio_stream(self, fcio_stream: FCIO) -> None:
 
         self.key_list = [
-            f"fsp_event_{get_key(fcio_stream.config.streamid, 0, 0)}",
-            f"fsp_eventheader_{get_key(fcio_stream.config.streamid, 0, 0)}",
+            f"swtid_{fcio_stream.config.streamid & 0xFFFF}/event",
+            f"swtid_{fcio_stream.config.streamid & 0xFFFF}/evt_hdr",
         ]
 
     def get_decoded_values(self, key: int = None) -> dict[str, dict[str, Any]]:
@@ -815,9 +814,9 @@ class FSPEventDecoder(DataDecoder):
     ) -> bool:
 
         if is_header:
-            key = f"fsp_eventheader_{get_key(fcio.config.streamid, 0, 0)}"
+            key = f"swtid_{fcio.config.streamid & 0xFFFF}/evt_hdr"
         else:
-            key = f"fsp_event_{get_key(fcio.config.streamid, 0, 0)}"
+            key = f"swtid_{fcio.config.streamid & 0xFFFF}/event"
 
         if key not in fsp_evt_rbkd:
             return False

--- a/src/daq2lh5/fc/fc_fsp_decoder.py
+++ b/src/daq2lh5/fc/fc_fsp_decoder.py
@@ -228,6 +228,9 @@ class FSPConfigDecoder(DataDecoder):
     def get_decoded_values(self, key: int = None) -> dict[str, dict[str, Any]]:
         return self.decoded_values
 
+    def get_key_lists(self) -> list[list[int | str]]:
+        return [copy.deepcopy(self.key_list)]
+
     def decode_packet(
         self,
         fcio: FCIO,
@@ -658,6 +661,9 @@ class FSPConfigDecoder(DataDecoder):
             "dsp_ct_thresholds",
             lgdo.Array(np.array(ct["thresholds"], dtype="uint16")[:ct_n_traces]),
         )
+
+        self.key_list.append(f"swtid_{fcio.config.streamid & 0xFFFF}/config")
+
         return self.fsp_config
 
     def make_lgdo(self, key: int | str = None, size: int = None) -> lgdo.Struct:
@@ -876,7 +882,7 @@ class FSPEventDecoder(DataDecoder):
         if lens > 0:
             tbl["obs_ps_hwm_prescaled_trace_idx"].flattened_data.nda[
                 start:end
-            ] = fcio.fsp.event.obs_ps_hwm_prescaled_trace_ix
+            ] = fcio.fsp.event.obs_ps_hwm_prescaled_trace_idx
         tbl["obs_ps_hwm_prescaled_trace_idx"].cumulative_length[loc] = end
 
         fsp_evt_rb.loc += 1

--- a/src/daq2lh5/fc/fc_status_decoder.py
+++ b/src/daq2lh5/fc/fc_status_decoder.py
@@ -121,8 +121,8 @@ fc_status_decoded_values = {
 }
 
 
-def get_key(streamid, reqid):
-    return (streamid & 0xFFFF) * 1000000 + (reqid & 0xFFFF)
+def get_key(reqid):
+    return (reqid & 0xFFFF)
 
 
 def get_fcid(key: int) -> int:
@@ -167,20 +167,21 @@ class FCStatusDecoder(DataDecoder):
         # the number of master cards is the sum of top and sub masters,
         # if there is more than one, the first is the top master
         # the rest is a sub master card.
+        fcid = fcio_stream.config.streamid & 0xFFFF
         for i in range(fcio_stream.config.mastercards):
             if i == 0:
-                key = get_key(fcio_stream.config.streamid, 0)
+                key = get_key(0)
             else:
-                key = get_key(fcio_stream.config.streamid, 0x4000 + i - 1)
-            self.key_list.append(key)
+                key = get_key(0x4000 + i - 1)
+            self.key_list.append(f"fcid_{fcid}/status/card{key}")
 
         for i in range(fcio_stream.config.triggercards):
-            key = get_key(fcio_stream.config.streamid, 0x1000 + i)
-            self.key_list.append(key)
+            key = get_key(0x1000 + i)
+            self.key_list.append(f"fcid_{fcid}/status/card{key}")
 
         for i in range(fcio_stream.config.adccards):
-            key = get_key(fcio_stream.config.streamid, 0x2000 + i)
-            self.key_list.append(key)
+            key = get_key(0x2000 + i)
+            self.key_list.append(f"fcid_{fcid}/status/card{key}")
 
     def get_key_lists(self) -> list[list[int | str]]:
         return [copy.deepcopy(self.key_list)]
@@ -220,7 +221,9 @@ class FCStatusDecoder(DataDecoder):
         """
         any_full = False
         for card_data in fcio.status.data:
-            key = get_key(fcio.config.streamid, card_data.reqid)
+            fcid = fcio.config.streamid & 0xFFFF
+            cardid = get_key(card_data.reqid)
+            key = f"fcid_{fcid}/status/card{cardid}"
             if key not in status_rbkd:
                 continue
 

--- a/src/daq2lh5/fc/fc_streamer.py
+++ b/src/daq2lh5/fc/fc_streamer.py
@@ -148,7 +148,8 @@ class FCStreamer(DataStreamer):
                 if len(config_rb_list) != 1:
                     log.warning(
                         f"config_rb_list for {config_decoder} had length {len(config_rb_list)}, "
-                        "ignoring all but the first"
+                        "ignoring all but the first. "
+                        f"{config_rb_list}"
                     )
                 rb = config_rb_list[0]
             else:

--- a/src/daq2lh5/orca/orca_fcio.py
+++ b/src/daq2lh5/orca/orca_fcio.py
@@ -129,11 +129,11 @@ class ORFCIOConfigDecoder(OrcaDecoder):
         self.decoded_values = copy.deepcopy(self.decoder.get_decoded_values())
 
         for fcid in self.fc_hdr_info["fsp_enabled"]:
-            key = get_key(fcid, 0, 0)
+            key = fcid
             self.key_list["fc_config"].append(key)
             if self.fc_hdr_info["fsp_enabled"][fcid]:
                 self.fsp_decoder = FSPConfigDecoder()
-                self.key_list["fsp_config"].append(f"fsp_config_{key}")
+                self.key_list["fsp_config"].append(f"swtid_{key}")
         self.max_rows_in_packet = 1
 
     def get_key_lists(self) -> list[list[int, str]]:
@@ -165,12 +165,12 @@ class ORFCIOConfigDecoder(OrcaDecoder):
         config_rbkd = rbl.get_keyed_dict()
 
         # TODO: the decoders could fetch lgdo's using it's key_list
-        fc_key = get_key(fcio_stream.config.streamid, 0, 0)
+        fc_key = fcio_stream.config.streamid & 0xFFFF
         any_full = self.decoder.decode_packet(
             fcio_stream, config_rbkd[fc_key], packet_id
         )
         if self.fsp_decoder is not None:
-            fsp_key = f"fsp_config_{get_key(fcio_stream.config.streamid, 0, 0)}"
+            fsp_key = f"fsp_config_{fcio_stream.config.streamid & 0xFFFF}"
             any_full |= self.fsp_decoder.decode_packet(
                 fcio_stream, config_rbkd[fsp_key], packet_id
             )
@@ -208,7 +208,7 @@ class ORFCIOStatusDecoder(OrcaDecoder):
 
             if self.fc_hdr_info["fsp_enabled"][fcid]:
                 key = get_key(fcid, 0, 0)
-                self.key_list["fsp_status"].append(f"fsp_status_{key}")
+                self.key_list["fsp_status"].append(f"swtid_{key}")
                 self.fsp_decoder = FSPStatusDecoder()
         self.max_rows_in_packet = max(self.fc_hdr_info["n_card"].values()) + 1
 
@@ -276,12 +276,12 @@ class ORFCIOEventHeaderDecoder(OrcaDecoder):
 
         key_list = self.fc_hdr_info["key_list"]
         for fcid in key_list:
-            key = get_key(fcid, 0, 0)
+            key = fcid
             self.key_list["fc_eventheader"].append(key)
             self.decoded_values[fcid] = copy.deepcopy(self.decoder.get_decoded_values())
             if self.fc_hdr_info["fsp_enabled"][fcid]:
                 self.fsp_decoder = FSPEventDecoder()
-                self.key_list["fsp_eventheader"].append(f"fsp_eventheader_{key}")
+                self.key_list["fsp_eventheader"].append(f"swtid_{key}")
 
         self.max_rows_in_packet = 1
 
@@ -353,8 +353,8 @@ class ORFCIOEventDecoder(OrcaDecoder):
                 "wf_len"
             ][fcid]
             if self.fc_hdr_info["fsp_enabled"][fcid]:
-                key = get_key(fcid, 0, 0)
-                self.key_list["fsp_event"].append(f"fsp_event_{key}")
+                key = fcid
+                self.key_list["fsp_event"].append(f"swtid_{key}")
                 self.fsp_decoder = FSPEventDecoder()
         self.max_rows_in_packet = max(self.fc_hdr_info["n_adc"].values())
 

--- a/tests/fc/test_fc_streamer.py
+++ b/tests/fc/test_fc_streamer.py
@@ -29,7 +29,11 @@ def test_default_rb_lib(lgnd_test_data):
     assert "FSPStatusDecoder" in rb_lib.keys()
     assert rb_lib["FCConfigDecoder"][0].out_name == "FCConfig"
     assert rb_lib["FCStatusDecoder"][0].out_name == "FCStatus"
-    assert rb_lib["FCStatusDecoder"][0].key_list == [0, 8192]
+    # the test dataset was taken with default streamid 0
+    assert rb_lib["FCStatusDecoder"][0].key_list == [
+        "fcid_0/status/card0",
+        "fcid_0/status/card8192",
+    ]
     assert rb_lib["FCEventDecoder"][0].out_name == "FCEvent"
     assert rb_lib["FCEventDecoder"][0].key_list == [52800 + _ for _ in range(0, 6)]
     assert rb_lib["FCEventHeaderDecoder"][0].out_name == "FCEventHeader"


### PR DESCRIPTION
Changes the key schema of the all non-event decoders for FC/OrcaFC decoders. Instead of trying to have numerical and/or short keys, they are compositions of listener id and record type.
All keys derived from fcio records are prepended with `fcid_{listenerid}/`, while software trigger records are prepended with `swtid_{listenerid}/`.
In addition `evt_hdr` tables from fc and swt have the same length now, while `swtid_{listenerid}/event` tables have the same length as each channel raw data table for non-sparse data. This makes swt flag application to the waveform tables straightforward.
In sparse mode these flags can be applied by matching the `packet_id` column between swt tables and channel tables.

This example type shows the new keys decoded from a testfile:
```
/extra
├── OrcaHeader · string 
├── RunControl · table{subrun_number,runstartorstop,quickstartrun,remotecontrolrun,heartbeatrecord,endsubrunrecord,startsubrunrecord,run_number,time} 
│   ├── endsubrunrecord · array<1>{bool} 
│   ├── heartbeatrecord · array<1>{bool} 
│   ├── quickstartrun · array<1>{bool} 
│   ├── remotecontrolrun · array<1>{bool} 
│   ├── run_number · array<1>{real} 
│   ├── runstartorstop · array<1>{bool} 
│   ├── startsubrunrecord · array<1>{bool} 
│   ├── subrun_number · array<1>{real} 
│   └── time · array<1>{real} 
├── fcid_1 · HDF5 group 
│   ├── config · table{packet_id,nsamples,nadcs,ntriggers,streamid,adcbits,sumlength,blprecision,mastercards,triggercards,adccards,gps,tracemap} 
│   ├── evt_hdr · table{packet_id,fcid,board_id,fc_input,eventnumber,event_type,timestamp,runtime,lifetime,deadtime,deadinterval_nsec,numtraces,tracelist,baseline,daqenergy,ts_pps,ts_ticks,ts_maxticks,mu_offset_sec,mu_offset_usec,to_master_sec,delta_mu_usec,abs_delta_mu_usec,to_start_sec,to_start_usec,dr_start_pps,dr_start_ticks,dr_stop_pps,dr_stop_ticks,dr_maxticks,dr_ch_idx,dr_ch_len} 
│   └── status · HDF5 group 
├── fcid_2 · HDF5 group 
│   ├── config · table{packet_id,nsamples,nadcs,ntriggers,streamid,adcbits,sumlength,blprecision,mastercards,triggercards,adccards,gps,tracemap} 
│   └── status · HDF5 group 
└── swtid_1 · HDF5 group 
    ├── config · table{packet_id,buffer_max_states,buffer_window_nsec,trg_hwm_min_multiplicity,trg_hwm_prescale_ratio,trg_wps_prescale_ratio,trg_wps_coincident_sum_threshold,trg_wps_sum_threshold,trg_wps_prescale_rate,trg_hwm_prescale_rate,trg_wps_ref_flags_hwm,trg_wps_ref_flags_ct,trg_wps_ref_flags_wps,trg_wps_ref_map_idx,trg_enabled_write_flags_trigger,trg_enabled_write_flags_event,trg_pre_trigger_window_nsec,trg_post_trigger_window_nsec,dsp_wps_tracemap_format,dsp_wps_tracemap_indices,dsp_wps_tracemap_enabled,dsp_wps_tracemap_label,dsp_wps_gains,dsp_wps_thresholds,dsp_wps_lowpass,dsp_wps_shaping_widths,dsp_wps_margin_front,dsp_wps_margin_back,dsp_wps_start_sample,dsp_wps_stop_sample,dsp_wps_dsp_max_margin_front,dsp_wps_dsp_max_margin_back,dsp_wps_apply_gain_scaling,dsp_wps_sum_window_size,dsp_wps_sum_window_start_sample,dsp_wps_sum_window_stop_sample,dsp_wps_sub_event_sum_threshold,dsp_hwm_tracemap_format,dsp_hwm_tracemap_indices,dsp_hwm_tracemap_enabled,dsp_hwm_tracemap_label,dsp_hwm_fpga_energy_threshold_adc,dsp_ct_tracemap_format,dsp_ct_tracemap_indices,dsp_ct_tracemap_enabled,dsp_ct_tracemap_label,dsp_ct_thresholds} 
    ├── event · table{packet_id,is_written,is_extended,is_consecutive,is_hwm_prescaled,is_hwm_multiplicity,is_wps_sum,is_wps_coincident_sum,is_wps_prescaled,is_ct_multiplicity,obs_wps_sum_value,obs_wps_sum_offset,obs_wps_sum_multiplicity,obs_wps_max_peak_value,obs_wps_max_peak_offset,obs_hwm_hw_multiplicity,obs_hwm_sw_multiplicity,obs_hwm_max_value,obs_hwm_min_value,obs_ct_multiplicity,obs_ct_trace_idx,obs_ct_max,obs_ps_hwm_prescaled_trace_idx,obs_evt_nconsecutive} 
    ├── evt_hdr · table{packet_id,is_written,is_extended,is_consecutive,is_hwm_prescaled,is_hwm_multiplicity,is_wps_sum,is_wps_coincident_sum,is_wps_prescaled,is_ct_multiplicity,obs_wps_sum_value,obs_wps_sum_offset,obs_wps_sum_multiplicity,obs_wps_max_peak_value,obs_wps_max_peak_offset,obs_hwm_hw_multiplicity,obs_hwm_sw_multiplicity,obs_hwm_max_value,obs_hwm_min_value,obs_ct_multiplicity,obs_ct_trace_idx,obs_ct_max,obs_ps_hwm_prescaled_trace_idx,obs_evt_nconsecutive} 
    └── status · table{packet_id,start_time,log_time,dt_logtime,runtime,n_read_events,n_written_events,n_discarded_events,dt_n_read_events,dt_n_written_events,dt_n_discarded_events,dt,dt_rate_read_events,dt_rate_write_events,dt_rate_discard_events,avg_rate_read_events,avg_rate_write_events,avg_rate_discard_events} 
```

In addition the following bugs were fixed:
- typo in prescaling attribute of swt event
- fcio wrapped packets in orca don't try to read beyond the packet size now, thereby preventing the fcio stream from being in error state.
- decoders which have different decoded values depending on listenerid (like different waveform length) return lists of keylists to allocate multiple buffers when no out_spec is given.