### PR TITLE
updated CoMPASS handling for more flexibility

### DIFF
--- a/src/daq2lh5/compass/compass_header_decoder.py
+++ b/src/daq2lh5/compass/compass_header_decoder.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import logging
 
 import lgdo
+import numpy as np
 
 from ..data_decoder import DataDecoder
 from .compass_config_parser import compass_config_to_struct
@@ -19,9 +20,7 @@ class CompassHeaderDecoder(DataDecoder):
         super().__init__(*args, **kwargs)
         self.config = None  # initialize to none, because compass_config_to_struct always returns a struct
 
-    def decode_header(
-        self, in_stream: bytes, config_file: str = None, wf_len: int = None
-    ) -> dict:
+    def decode_header(self, in_stream: bytes, config_file: str = None) -> dict:
         """Decode the CoMPASS file header, and add CoMPASS config data to the header, if present.
 
         Parameters
@@ -30,8 +29,6 @@ class CompassHeaderDecoder(DataDecoder):
             The stream of data to have its header decoded
         config_file
             The config file for the CoMPASS data, if present
-        wf_len
-            The length of the first waveform in the file, only pre-calculated when the config_file is none
 
         Returns
         -------
@@ -39,27 +36,203 @@ class CompassHeaderDecoder(DataDecoder):
             A dict containing the header information, as well as the important config information
             of wf_len and num_enabled_channels
         """
-        self.config = compass_config_to_struct(config_file, wf_len)
-
+        wf_len = None
         config_names = [
             "energy_channels",  # energy is given in channels (0: false, 1: true)
             "energy_calibrated",  # energy is given in keV/MeV, according to the calibration (0: false, 1: true)
             "energy_short",  # energy short is present (0: false, 1: true)
             "waveform_samples",  # waveform samples are present (0: false, 1: true)
-        ]
-        header_in_bytes = in_stream.read(
-            2
-        )  # we always have to read in the first 2 bytes of the header for CoMPASS v2 files
-        header_in_binary = bin(int.from_bytes(header_in_bytes, byteorder="little"))
-        header_as_list = str(header_in_binary)[
-            ::-1
-        ]  # reverse it as we care about bit 0, bit 1, etc.
+            "header_present",  # there is a 2 byte header present in the file (0: false, 1: true)
+        ]  # need to determine which of these are present in a file
 
-        for i, name in enumerate(config_names):
+        # First need to check if the first two bytes are of the form 0xCAEx
+        # CoMPASS specs say that every file should start with this header, but if CoMPASS writes size-limited files, then this header may not be present in *all* files...
+        header_in_bytes = in_stream.read(2)
+
+        if header_in_bytes[-1] == int.from_bytes(b"\xca", byteorder="big"):
+            log.debug("header is present in file.")
+            header_in_binary = bin(int.from_bytes(header_in_bytes, byteorder="little"))
+            header_as_list = str(header_in_binary)[
+                ::-1
+            ]  # reverse it as we care about bit 0, bit 1, etc.
+            header_dict = dict(
+                {
+                    "energy_channels": int(header_as_list[0]) == 1,
+                    "energy_calibrated": int(header_as_list[1]) == 1,
+                    "energy_channels_calibrated": int(header_as_list[0])
+                    == 1 & int(header_as_list[1])
+                    == 1,
+                    "energy_short": int(header_as_list[2]) == 1,
+                    "waveform_samples": int(header_as_list[3]) == 1,
+                    "header_present": True,
+                }
+            )
+
+            # if we don't have the wf_len, get it now
+
+            if config_file is None:
+                if header_dict["waveform_samples"] == 0:
+                    wf_len = 0
+                else:
+                    wf_byte_len = 4
+                    bytes_to_read = (
+                        12  # covers 2-byte board, 2-byte channel, 8-byte time stamp
+                    )
+                    bytes_to_read += (
+                        2 * header_dict["energy_channels"]
+                        + 8 * header_dict["energy_calibrated"]
+                        + 2 * header_dict["energy_short"]
+                    )
+                    bytes_to_read += 4 + 1  # 4-byte flags, 1-byte waveform code
+                    first_bytes = in_stream.read(bytes_to_read + wf_byte_len)
+
+                    wf_len = np.frombuffer(
+                        first_bytes[bytes_to_read : bytes_to_read + wf_byte_len],
+                        dtype=np.uint32,
+                    )[0]
+
+        # if header is not present, we need to play some tricks
+        # either energy short is present or not
+        # and one of three options for energy (ADC, calibrated, both)
+        else:
+            # If the 2 byte header is not present, then we have read in the board by accident
+            header_in_bytes += in_stream.read(
+                10
+            )  # read in the 2-byte ch and 8-byte timestamp
+            bytes_read = 12
+            fixed_header_start_len = (
+                12  # always 12 bytes: 2-byte board, 2-byte channel, 8-byte timestamp
+            )
+            possible_energy_header_byte_lengths = [
+                2,
+                8,
+                10,
+            ]  # either ADC, Calibrated, or both
+            possible_energy_short_header_byte_lengths = [
+                0,
+                2,
+            ]  # energy short is present or not
+            fixed_header_part = 5  # 5 bytes from flags + code
+            wf_len_bytes = 4  # wf_len is 4 bytes long
+
+            for prefix in possible_energy_header_byte_lengths:
+                terminate = False
+                for suffix in possible_energy_short_header_byte_lengths:
+
+                    # ---- first packet -------
+                    # don't read more than we have to, check how many more bytes we need to read in
+                    difference = (
+                        fixed_header_start_len
+                        + prefix
+                        + suffix
+                        + fixed_header_part
+                        + wf_len_bytes
+                        - bytes_read
+                    )
+                    if difference > 0:
+                        # just read a bit more data
+                        header_in_bytes += in_stream.read(difference)
+                        bytes_read += difference
+
+                    wf_len_guess = np.frombuffer(
+                        header_in_bytes[
+                            fixed_header_start_len
+                            + prefix
+                            + suffix
+                            + fixed_header_part : fixed_header_start_len
+                            + prefix
+                            + suffix
+                            + fixed_header_part
+                            + wf_len_bytes
+                        ],
+                        dtype=np.uint32,
+                    )[0]
+
+                    # read in the first waveform data
+                    difference = (
+                        fixed_header_start_len
+                        + prefix
+                        + suffix
+                        + fixed_header_part
+                        + wf_len_bytes
+                        + 2 * wf_len_guess
+                        - bytes_read
+                    )
+                    if difference > 0:
+                        header_in_bytes += in_stream.read(2 * wf_len_guess)
+                        bytes_read += 2 * wf_len_guess
+
+                    # ------ second packet header ----------
+                    difference = (
+                        2
+                        * (
+                            fixed_header_start_len
+                            + prefix
+                            + suffix
+                            + fixed_header_part
+                            + wf_len_bytes
+                        )
+                        + 2 * wf_len_guess
+                        - bytes_read
+                    )
+                    if difference > 0:
+                        header_in_bytes += in_stream.read(difference)
+                        bytes_read += (
+                            fixed_header_start_len
+                            + prefix
+                            + suffix
+                            + fixed_header_part
+                            + wf_len_bytes
+                        )
+                    wf_len_guess_2 = np.frombuffer(
+                        header_in_bytes[
+                            2
+                            * (
+                                fixed_header_start_len
+                                + prefix
+                                + suffix
+                                + fixed_header_part
+                            )
+                            + wf_len_bytes
+                            + 2
+                            * wf_len_guess : 2
+                            * (
+                                fixed_header_start_len
+                                + prefix
+                                + suffix
+                                + fixed_header_part
+                                + wf_len_bytes
+                            )
+                            + 2 * wf_len_guess
+                        ],
+                        dtype=np.uint32,
+                    )[0]
+
+                    # if the waveform lengths agree, then we can stride packets correctly
+                    if wf_len_guess_2 == wf_len_guess:
+                        header_dict = dict(
+                            {
+                                "energy_channels": prefix == 2,
+                                "energy_calibrated": prefix == 8,
+                                "energy_channels_calibrated": prefix == 10,
+                                "energy_short": suffix == 2,
+                                "waveform_samples": wf_len != 0,
+                                "header_present": False,
+                            }
+                        )
+                        wf_len = wf_len_guess
+                        terminate = True
+                        break
+                if terminate:
+                    break
+
+        self.config = compass_config_to_struct(config_file, wf_len)
+
+        for name in config_names:
             if name in self.config:
                 log.warning(f"{name} already in self.config. skipping...")
                 continue
-            value = int(header_as_list[i])
+            value = int(header_dict[name])
             self.config.add_field(
                 str(name), lgdo.Scalar(value)
             )  # self.config is a struct

--- a/tests/compass/conftest.py
+++ b/tests/compass/conftest.py
@@ -40,7 +40,6 @@ def compass_config_no_settings(lgnd_test_data):
     test_file = lgnd_test_data.get_path("compass/compass_test_data.BIN")
     in_stream = open(test_file, "rb")
     compass_config_file = None
-    wf_len = 1000
-    decoder.decode_header(in_stream, compass_config_file, wf_len)
+    decoder.decode_header(in_stream, compass_config_file)
     in_stream.close()
     return decoder.config

--- a/tests/compass/test_compass_header_decoder.py
+++ b/tests/compass/test_compass_header_decoder.py
@@ -46,6 +46,7 @@ def test_values(compass_config):
         "energy_channels": 1,
         "energy_short": 1,
         "waveform_samples": 1,
+        "header_present": 1,
     }
     # We have a nested struct, so we need some nasty recursion
     for key in compass_config.keys():
@@ -136,6 +137,7 @@ def test_values_no_config(compass_config_no_settings):
         "energy_channels": 1,
         "energy_short": 1,
         "waveform_samples": 1,
+        "header_present": 1,
     }
     # We have a nested struct, so we need some nasty recursion
     for key in compass_config_no_settings.keys():


### PR DESCRIPTION
sometimes CoMPASS will emit files that are missing the 2-byte header as specified in the manual. This update now checks two packets to see what information is present in the header, and allows for decoding of files without the 2-byte header.