### PR TITLE
Auto decode fcio config in Orca stream.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -165,3 +165,6 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+
+# pixi environments
+.pixi

--- a/src/daq2lh5/fc/fc_event_decoder.py
+++ b/src/daq2lh5/fc/fc_event_decoder.py
@@ -152,24 +152,41 @@ class FCEventDecoder(DataDecoder):
             tbl["board_id"].nda[loc] = fcio.event.card_address[ii]
             tbl["fc_input"].nda[loc] = fcio.event.card_channel[ii]
             tbl["event_type"].nda[loc] = fcio.event.type
-            tbl["eventnumber"].nda[loc] = fcio.event.timestamp[0]
             tbl["numtraces"].nda[loc] = fcio.event.num_traces
-            tbl["ts_pps"].nda[loc] = fcio.event.timestamp[1]
-            tbl["ts_ticks"].nda[loc] = fcio.event.timestamp[2]
-            tbl["ts_maxticks"].nda[loc] = fcio.event.timestamp[3]
-            tbl["mu_offset_sec"].nda[loc] = fcio.event.timeoffset[0]
-            tbl["mu_offset_usec"].nda[loc] = fcio.event.timeoffset[1]
-            tbl["to_master_sec"].nda[loc] = fcio.event.timeoffset[2]
-            tbl["delta_mu_usec"].nda[loc] = fcio.event.timeoffset[3]
-            tbl["abs_delta_mu_usec"].nda[loc] = fcio.event.timeoffset[4]
-            tbl["to_start_sec"].nda[loc] = fcio.event.timeoffset[5]
-            tbl["to_start_usec"].nda[loc] = fcio.event.timeoffset[6]
-            tbl["dr_start_pps"].nda[loc] = fcio.event.deadregion[0]
-            tbl["dr_start_ticks"].nda[loc] = fcio.event.deadregion[1]
-            tbl["dr_stop_pps"].nda[loc] = fcio.event.deadregion[2]
-            tbl["dr_stop_ticks"].nda[loc] = fcio.event.deadregion[3]
-            tbl["dr_maxticks"].nda[loc] = fcio.event.deadregion[4]
-            # if event_type == 11: provides the same check
+
+            # the order of names is crucial here!
+            timestamp_names = [
+                "eventnumber",
+                "ts_pps",
+                "ts_ticks",
+                "ts_maxticks",
+            ]
+            for name, value in zip(timestamp_names, fcio.event.timestamp):
+                tbl[name].nda[loc] = value
+
+            timeoffset_names = [
+                "mu_offset_sec",
+                "mu_offset_usec",
+                "to_master_sec",
+                "delta_mu_usec",
+                "abs_delta_mu_usec",
+                "to_start_sec",
+                "to_start_usec",
+            ]
+            for name, value in zip(timeoffset_names, fcio.event.timeoffset):
+                tbl[name].nda[loc] = value
+
+            deadregion_names = [
+                "dr_start_pps",
+                "dr_start_ticks",
+                "dr_stop_pps",
+                "dr_stop_ticks",
+                "dr_maxticks",
+            ]
+            for name, value in zip(deadregion_names, fcio.event.deadregion[:5]):
+                tbl[name].nda[loc] = value
+
+            # if event_type == 11: would provide the same check
             # however, the usage of deadregion[5]/[6] must never change
             # and it will always be present if deadregion[7..] is ever used
             if fcio.event.deadregion_size >= 7:
@@ -179,7 +196,7 @@ class FCEventDecoder(DataDecoder):
                 tbl["dr_ch_idx"].nda[loc] = 0
                 tbl["dr_ch_len"].nda[loc] = fcio.config.adcs
 
-            # The following values are calculated values by fcio-py
+            # The following values are calculated by fcio-py, derived from fields above.
             tbl["timestamp"].nda[loc] = fcio.event.unix_time_utc_sec
             tbl["deadinterval_nsec"].nda[loc] = fcio.event.dead_interval_nsec[ii]
             tbl["deadtime"].nda[loc] = fcio.event.dead_time_sec[ii]

--- a/src/daq2lh5/fc/fc_eventheader_decoder.py
+++ b/src/daq2lh5/fc/fc_eventheader_decoder.py
@@ -14,9 +14,12 @@ log = logging.getLogger(__name__)
 
 def get_key(streamid: int, card_address: int, card_input: int, iwf: int = -1) -> int:
     if streamid > 0 or iwf < 0:
-        # For backwards compatibility only the lower 16-bit of the streamid are
-        # used.
-        return (streamid & 0xFFFF) * 1000000 + card_address * 100 + card_input
+        # For backwards compatibility only the lower 16-bit of the streamid are used.
+        return (
+            (int(streamid) & 0xFFFF) * 1000000
+            + int(card_address) * 100
+            + int(card_input)
+        )
     else:
         return iwf
 

--- a/src/daq2lh5/orca/orca_streamer.py
+++ b/src/daq2lh5/orca/orca_streamer.py
@@ -383,8 +383,6 @@ class OrcaStreamer(DataStreamer):
             chunk_mode=chunk_mode,
             out_stream=out_stream,
         )
-        if rb_lib is None:
-            rb_lib = self.rb_lib
         good_buffers = []
         for data_id in self.decoder_id_dict.keys():
             name = id_to_dec_name_dict[data_id]
@@ -400,8 +398,8 @@ class OrcaStreamer(DataStreamer):
         log.debug(f"rb_lib = {self.rb_lib}")
 
         # return header raw buffer
-        if "OrcaHeaderDecoder" in rb_lib:
-            header_rb_list = rb_lib["OrcaHeaderDecoder"]
+        if "OrcaHeaderDecoder" in self.rb_lib:
+            header_rb_list = self.rb_lib["OrcaHeaderDecoder"]
             if len(header_rb_list) != 1:
                 log.warning(
                     f"header_rb_list had length {len(header_rb_list)}, ignoring all but the first"

--- a/src/daq2lh5/orca/orca_streamer.py
+++ b/src/daq2lh5/orca/orca_streamer.py
@@ -366,8 +366,7 @@ class OrcaStreamer(DataStreamer):
             shift_data_id=False
         )
         instantiated_decoders = {"OrcaHeaderDecoder": self.header_decoder}
-        for data_id in id_to_dec_name_dict.keys():
-            name = id_to_dec_name_dict[data_id]
+        for data_id, name in id_to_dec_name_dict.items():
             if name not in instantiated_decoders:
                 if name not in globals():
                     self.missing_decoders.append(data_id)

--- a/src/daq2lh5/orca/orca_streamer.py
+++ b/src/daq2lh5/orca/orca_streamer.py
@@ -351,8 +351,11 @@ class OrcaStreamer(DataStreamer):
         if rb_lib is not None and "*" not in rb_lib:
             keep_decoders = []
             for name in decoder_names:
-                # Decoding of FCIOConfig is required to open the wrapped fcio stream (in orca_fcio.py).
-                # With `out_stream == ''` the buffer will be allocated and decoded, but not written.
+                # Decoding ORFCIO streams requires decoding ORFCIOConfig packets,
+                # as it opens the wrapped fcio stream (in orca_fcio.py) and decodes the fields
+                # required for the other FCIO packets.
+                # With `out_stream == ''` the lgdo buffer will be allocated, and the packet
+                # decoded, but not written to the out_stream the user defined.
                 if name == "ORFCIOConfigDecoder" and name not in rb_lib:
                     rb_lib[name] = RawBufferList()
                     rb_lib[name].append(

--- a/tests/orca/test_orca_fcio.py
+++ b/tests/orca/test_orca_fcio.py
@@ -48,7 +48,7 @@ def test_orfcio_config_decoding_swt(orca_stream_fcio_swt, fcio_swt_packets):
     assert name == "ORFCIOConfigDecoder"
 
 
-def test_orfcio_waveform_decoding_swt(orca_stream_fcio_swt, fcio_swt_packets):
+def test_orfcio_eventheader_decoding_swt(orca_stream_fcio_swt, fcio_swt_packets):
     wf_packet = fcio_swt_packets[1]
     assert wf_packet is not None
 


### PR DESCRIPTION
If an external `out_spec` is used in `build_raw` which doesn't contain an `ORFCIOConfigDecoder` statement, the Orca paket containing this FCIO record is skipped. However the config is required to decode all other records - tracked by fcio_stream objects in `orca_fcio.py`.

This PR adds an "empty" RawBuffer for the `ORFCIOConfigDecoder` to the `rb_lib` _if_ provided by the user, otherwise the default rb lib will add it.
Due to `out_spec == ''` the lgdo is never written to disc, just allocated (and decoded into).

On the way some minor inconsistency fixes were added.

This solution is not the most elegant, but any other (I think) would require rewriting the decoding to use embedded streams (fcio stream within orca streamer) and not embedded decoders. I had explored this option previously, but it would require more rewrites of existing functionality. 
If anyone has a better way to enforce the config decoding, please ..!