### PR TITLE
WIP: Update fcio dependency version to 0.9.4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ classifiers = [
 requires-python = ">=3.9"
 dependencies = [
     "dspeed>=2.0",
-    "fcio>=0.7.9, <0.9",
+    "fcio>==0.9.4",
     "h5py>=3.2.0",
     "hdf5plugin",
     "legend-pydataobj>=1.6",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ classifiers = [
 requires-python = ">=3.9"
 dependencies = [
     "dspeed>=2.0",
-    "fcio>==0.9.4",
+    "fcio>=0.9.4",
     "h5py>=3.2.0",
     "hdf5plugin",
     "legend-pydataobj>=1.6",


### PR DESCRIPTION
Since version 0.7.9 (0.8 was skipped) mostly dependency updates were performed.

The logic changes are as follows:

- Add all time calculations to trigger traces. This does not affect legend style data, and is not used in daq2lh5-
- Add WaitMessage to get_record. This change enables timeouts on file reading. Allows the fcio reader to wait for new events even on disc. Does not affect file conversion.
- _Max run start time more conservative._ This change affects the calculation of the on-board `lifetime` and `runtime`. In some cases both counters were assuming earlier trigger enable timestamps than the HW actually did, which lead to an overestimation of the `lifetime` and `runtime`
- Previously unit tests failed with version >0.9 because cython introduced a regression. For the time being `fcio-py` is fixing it's version to `cython ~v3.1`. 