### PR TITLE
Add a public API for decoding DAQ data in memory

### DIFF
--- a/src/daq2lh5/__init__.py
+++ b/src/daq2lh5/__init__.py
@@ -19,6 +19,6 @@ Currently we support the following DAQ data formats:
 """
 
 from ._version import version as __version__
-from .build_raw import build_raw
+from .build_raw import build_raw, get_streamer
 
-__all__ = ["build_raw", "__version__"]
+__all__ = ["build_raw", "get_streamer", "__version__"]

--- a/src/daq2lh5/__init__.py
+++ b/src/daq2lh5/__init__.py
@@ -19,6 +19,6 @@ Currently we support the following DAQ data formats:
 """
 
 from ._version import version as __version__
-from .build_raw import build_raw, get_streamer
+from .build_raw import build_raw, get_streamer, open_stream
 
-__all__ = ["build_raw", "get_streamer", "__version__"]
+__all__ = ["build_raw", "get_streamer", "open_stream", "__version__"]

--- a/src/daq2lh5/build_raw.py
+++ b/src/daq2lh5/build_raw.py
@@ -11,12 +11,86 @@ from tqdm.auto import tqdm
 
 from . import utils
 from .compass.compass_streamer import CompassStreamer
+from .data_streamer import DataStreamer
 from .fc.fc_streamer import FCStreamer
 from .llama.llama_streamer import LLAMAStreamer
 from .orca.orca_streamer import OrcaStreamer
 from .raw_buffer import RawBufferLibrary, write_to_lh5_and_clear
 
 log = logging.getLogger(__name__)
+
+
+def get_streamer(
+    in_stream: str,
+    in_stream_type: str = None,
+    compass_config_file: str = None,
+) -> DataStreamer:
+    """Get the appropriate streamer for an input stream.
+
+    Parameters
+    ----------
+    in_stream
+        the path to the input stream. If `in_stream_type` is ``None``, the
+        stream type is deduced from the file extension (``fcio``, ``orca``,
+        ``bin``/``BIN``) or, lacking one, by testing the content for an ORCA
+        stream.
+    in_stream_type
+        ``'ORCA'``, ``'FlashCam'``, ``'LlamaDaq'``, ``'Compass'``, or ``None``
+        to auto-detect.
+    compass_config_file
+        configuration file for the CoMPASS decoder. If not ``None``,
+        auto-detection selects ``'Compass'``.
+
+    Returns
+    -------
+    streamer
+        a :class:`.DataStreamer` subclass instance appropriate for the
+        input stream, not yet opened.
+
+    Raises
+    ------
+    RuntimeError
+        if `in_stream_type` is ``None`` and auto-detection fails (unknown
+        file extension or content).
+    NotImplementedError
+        if `in_stream_type` is not supported (including ``'MGDO'``, which is
+        recognized but not yet implemented).
+    """
+    if in_stream_type is None:
+        filename = in_stream.split("/")[-1]
+        i_ext = filename.rfind(".")
+        if compass_config_file is not None:
+            in_stream_type = "Compass"
+        elif i_ext != -1:
+            ext = filename[i_ext + 1 :]
+            if ext == "fcio":
+                in_stream_type = "FlashCam"
+            elif ext == "orca":
+                in_stream_type = "ORCA"
+            elif ext == "bin" or ext == "BIN":
+                in_stream_type = "Compass"
+            else:
+                raise RuntimeError(
+                    f"unknown file extension {ext}. Specify in_stream_type"
+                )
+        else:
+            if OrcaStreamer.is_orca_stream(in_stream):
+                in_stream_type = "ORCA"
+            else:
+                raise RuntimeError("unknown file type. Specify in_stream_type")
+
+    if in_stream_type == "ORCA":
+        return OrcaStreamer()
+    elif in_stream_type == "FlashCam":
+        return FCStreamer()
+    elif in_stream_type == "Compass":
+        return CompassStreamer(compass_config_file)
+    elif in_stream_type == "LlamaDaq":
+        return LLAMAStreamer()
+    elif in_stream_type == "MGDO":
+        raise NotImplementedError("MGDO streaming not yet implemented")
+    else:
+        raise NotImplementedError(f"unknown input stream type {in_stream_type}")
 
 
 def build_raw(
@@ -98,29 +172,6 @@ def build_raw(
 
     in_stream_size = os.stat(in_stream).st_size
 
-    # try to guess the input stream type if it's not provided
-    if in_stream_type is None:
-        i_ext = in_stream.split("/")[-1].rfind(".")
-        if compass_config_file is not None:  # skip right away if compass
-            in_stream_type = "Compass"
-        elif i_ext != -1:
-            ext = in_stream.split("/")[-1][i_ext + 1 :]
-            if ext == "fcio":
-                in_stream_type = "FlashCam"
-            elif ext == "orca":
-                in_stream_type = "ORCA"
-            elif ext == "bin" or ext == "BIN":
-                in_stream_type = "Compass"
-            else:
-                raise RuntimeError(
-                    f"unknown file extension {ext}. Specify in_stream_type"
-                )
-        else:
-            if OrcaStreamer.is_orca_stream(in_stream):  # orca default is no ext
-                in_stream_type = "ORCA"
-            else:
-                raise RuntimeError("unknown file type. Specify in_stream_type")
-
     # process out_spec and setup rb_lib if specified
     rb_lib = None
     allowed_exts = [ext for exts in utils.__file_extensions__.values() for ext in exts]
@@ -178,19 +229,7 @@ def build_raw(
     t_start = time.time()
 
     # select the appropriate streamer for in_stream
-    streamer = None
-    if in_stream_type == "ORCA":
-        streamer = OrcaStreamer()
-    elif in_stream_type == "FlashCam":
-        streamer = FCStreamer()
-    elif in_stream_type == "Compass":
-        streamer = CompassStreamer(compass_config_file)
-    elif in_stream_type == "LlamaDaq":
-        streamer = LLAMAStreamer()
-    elif in_stream_type == "MGDO":
-        raise NotImplementedError("MGDO streaming not yet implemented")
-    else:
-        raise NotImplementedError(f"unknown input stream type {in_stream_type}")
+    streamer = get_streamer(in_stream, in_stream_type, compass_config_file)
 
     # initialize the stream and read header. Also initializes rb_lib
     if log.getEffectiveLevel() <= logging.INFO:

--- a/src/daq2lh5/build_raw.py
+++ b/src/daq2lh5/build_raw.py
@@ -5,7 +5,7 @@ import logging
 import os
 import time
 from collections.abc import Iterator
-from contextlib import contextmanager
+from contextlib import contextmanager, suppress
 
 import lh5
 import numpy as np
@@ -137,7 +137,14 @@ def open_stream(
         :class:`.RawBuffer`\\ s containing the file header data.
     """
     streamer = get_streamer(in_stream, in_stream_type, compass_config_file)
-    header_data = streamer.open_stream(in_stream, **open_kwargs)
+    try:
+        header_data = streamer.open_stream(in_stream, **open_kwargs)
+    except BaseException:
+        # open_stream may have acquired a resource before failing; release it
+        # best-effort, without letting a cleanup error mask the original one
+        with suppress(Exception):
+            streamer.close_stream()
+        raise
     try:
         yield streamer, header_data
     finally:

--- a/src/daq2lh5/build_raw.py
+++ b/src/daq2lh5/build_raw.py
@@ -4,6 +4,8 @@ import glob
 import logging
 import os
 import time
+from collections.abc import Iterator
+from contextlib import contextmanager
 
 import lh5
 import numpy as np
@@ -15,7 +17,7 @@ from .data_streamer import DataStreamer
 from .fc.fc_streamer import FCStreamer
 from .llama.llama_streamer import LLAMAStreamer
 from .orca.orca_streamer import OrcaStreamer
-from .raw_buffer import RawBufferLibrary, write_to_lh5_and_clear
+from .raw_buffer import RawBuffer, RawBufferLibrary, write_to_lh5_and_clear
 
 log = logging.getLogger(__name__)
 
@@ -91,6 +93,55 @@ def get_streamer(
         raise NotImplementedError("MGDO streaming not yet implemented")
     else:
         raise NotImplementedError(f"unknown input stream type {in_stream_type}")
+
+
+@contextmanager
+def open_stream(
+    in_stream: str,
+    in_stream_type: str = None,
+    compass_config_file: str = None,
+    **open_kwargs,
+) -> Iterator[tuple[DataStreamer, list[RawBuffer]]]:
+    """Open a DAQ stream of any supported type, guaranteeing closure.
+
+    Composes :func:`.get_streamer` and
+    :meth:`~.data_streamer.DataStreamer.open_stream`: selects the appropriate
+    streamer for `in_stream`, opens it, and yields it together with the
+    header data. The stream is closed on exit from the ``with`` block, also
+    when an exception is raised inside it.
+
+    Examples
+    --------
+    >>> with open_stream("daq.fcio") as (streamer, header_data):
+    ...     for chunk_list in streamer:
+    ...         do_something(chunk_list)
+
+    Parameters
+    ----------
+    in_stream
+        the path to the input stream, see :func:`.get_streamer`.
+    in_stream_type
+        ``'ORCA'``, ``'FlashCam'``, ``'LlamaDaq'``, ``'Compass'``, or ``None``
+        to auto-detect.
+    compass_config_file
+        configuration file for the CoMPASS decoder.
+    open_kwargs
+        keyword arguments forwarded to
+        :meth:`~.data_streamer.DataStreamer.open_stream` (e.g. `rb_lib`,
+        `buffer_size`, `chunk_mode`, `out_stream`).
+
+    Yields
+    ------
+    streamer, header_data
+        the opened :class:`.DataStreamer` and the list of
+        :class:`.RawBuffer`\\ s containing the file header data.
+    """
+    streamer = get_streamer(in_stream, in_stream_type, compass_config_file)
+    header_data = streamer.open_stream(in_stream, **open_kwargs)
+    try:
+        yield streamer, header_data
+    finally:
+        streamer.close_stream()
 
 
 def build_raw(

--- a/src/daq2lh5/data_streamer.py
+++ b/src/daq2lh5/data_streamer.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 import fnmatch
 import logging
 from abc import ABC, abstractmethod
+from collections.abc import Iterator
 
 from .raw_buffer import RawBuffer, RawBufferLibrary, RawBufferList
 
@@ -354,6 +355,26 @@ class DataStreamer(ABC):
         if not still_has_data:
             log.debug(f"decoding complete. flushing {len(list_of_rbs)} buffers")
         return list_of_rbs
+
+    def __iter__(self) -> Iterator[list[RawBuffer]]:
+        """Iterate over chunks of decoded data until the stream is exhausted.
+
+        Wraps :meth:`.read_chunk` and clears the consumed buffers after each
+        yield, as required prior to the next :meth:`.read_chunk` call.
+
+        Notes
+        -----
+        Buffers are reused across iterations: process or copy a yielded
+        chunk's data before advancing the iterator. Only the first
+        ``rb.loc`` rows of each ``rb.lgdo`` contain fresh data.
+        """
+        while True:
+            chunk_list = self.read_chunk()
+            if len(chunk_list) == 0:
+                return
+            yield chunk_list
+            for rb in chunk_list:
+                rb.loc = 0
 
     @abstractmethod
     def get_decoder_list(self) -> list:

--- a/tests/test_build_raw.py
+++ b/tests/test_build_raw.py
@@ -1,5 +1,6 @@
 import json
 import os
+import shutil
 from pathlib import Path
 
 import h5py
@@ -7,8 +8,12 @@ import lh5
 import pytest
 from lh5.compression import ULEB128ZigZagDiff
 
-from daq2lh5 import build_raw
+from daq2lh5 import build_raw, get_streamer
+from daq2lh5.compass.compass_streamer import CompassStreamer
 from daq2lh5.fc.fc_event_decoder import fc_event_decoded_values
+from daq2lh5.fc.fc_streamer import FCStreamer
+from daq2lh5.llama.llama_streamer import LLAMAStreamer
+from daq2lh5.orca.orca_streamer import OrcaStreamer
 
 config_dir = Path(__file__).parent / "configs"
 
@@ -351,3 +356,59 @@ def test_build_raw_orca_sis3316(lgnd_test_data, tmptestdir):
     )
 
     assert os.path.exists(out_file)
+
+
+@pytest.mark.parametrize(
+    "filename, streamer_class",
+    [
+        ("daq.fcio", FCStreamer),
+        ("daq.orca", OrcaStreamer),
+        ("daq.bin", CompassStreamer),
+        ("daq.BIN", CompassStreamer),
+    ],
+)
+def test_get_streamer_detects_extension(filename, streamer_class):
+    assert isinstance(get_streamer(f"/some/dir/{filename}"), streamer_class)
+
+
+@pytest.mark.parametrize(
+    "in_stream_type, streamer_class",
+    [
+        ("ORCA", OrcaStreamer),
+        ("FlashCam", FCStreamer),
+        ("Compass", CompassStreamer),
+        ("LlamaDaq", LLAMAStreamer),
+    ],
+)
+def test_get_streamer_explicit_type(in_stream_type, streamer_class):
+    assert isinstance(get_streamer("any.name", in_stream_type), streamer_class)
+
+
+def test_get_streamer_compass_config_implies_compass():
+    streamer = get_streamer("extensionless", compass_config_file="cfg.json")
+    assert isinstance(streamer, CompassStreamer)
+
+
+def test_get_streamer_detects_orca_content(lgnd_test_data, tmp_path):
+    orca_file = lgnd_test_data.get_path("orca/fc/L200-comm-20220519-phy-geds.orca")
+    noext = tmp_path / "extensionless_orca"
+    shutil.copyfile(orca_file, noext)
+    assert isinstance(get_streamer(str(noext)), OrcaStreamer)
+
+
+def test_get_streamer_errors(tmp_path):
+    # unknown file extension
+    with pytest.raises(RuntimeError):
+        get_streamer("daq.xyz")
+
+    # no extension and not ORCA content
+    junk = tmp_path / "junkfile"
+    junk.write_bytes(b"\xff" * 64)
+    with pytest.raises(RuntimeError):
+        get_streamer(str(junk))
+
+    # recognized but unimplemented / unknown stream types
+    with pytest.raises(NotImplementedError):
+        get_streamer("daq.fcio", "MGDO")
+    with pytest.raises(NotImplementedError):
+        get_streamer("daq.fcio", "NotADaq")

--- a/tests/test_build_raw.py
+++ b/tests/test_build_raw.py
@@ -8,7 +8,7 @@ import lh5
 import pytest
 from lh5.compression import ULEB128ZigZagDiff
 
-from daq2lh5 import build_raw, get_streamer
+from daq2lh5 import build_raw, get_streamer, open_stream
 from daq2lh5.compass.compass_streamer import CompassStreamer
 from daq2lh5.fc.fc_event_decoder import fc_event_decoded_values
 from daq2lh5.fc.fc_streamer import FCStreamer
@@ -412,3 +412,30 @@ def test_get_streamer_errors(tmp_path):
         get_streamer("daq.fcio", "MGDO")
     with pytest.raises(NotImplementedError):
         get_streamer("daq.fcio", "NotADaq")
+
+
+def test_open_stream(lgnd_test_data):
+    in_file = lgnd_test_data.get_path("fcio/L200-comm-20211130-phy-spms.fcio")
+
+    with open_stream(in_file, buffer_size=1024) as (streamer, header_data):
+        assert isinstance(streamer, FCStreamer)
+        assert len(header_data) > 0
+        n_rows = sum(
+            rb.loc
+            for chunk_list in streamer
+            for rb in chunk_list
+            if rb.out_name == "FCEvent"
+        )
+    assert n_rows == 300  # number of events in the test file
+
+
+def test_open_stream_closes_on_error(lgnd_test_data):
+    in_file = lgnd_test_data.get_path("fcio/L200-comm-20211130-phy-spms.fcio")
+
+    closed = []
+    with pytest.raises(ValueError):
+        with open_stream(in_file) as (streamer, _):
+            orig_close = streamer.close_stream
+            streamer.close_stream = lambda: (closed.append(True), orig_close())
+            raise ValueError("oops")
+    assert closed == [True]

--- a/tests/test_build_raw.py
+++ b/tests/test_build_raw.py
@@ -439,3 +439,22 @@ def test_open_stream_closes_on_error(lgnd_test_data):
             streamer.close_stream = lambda: (closed.append(True), orig_close())
             raise ValueError("oops")
     assert closed == [True]
+
+
+def test_open_stream_closes_on_open_failure(lgnd_test_data, monkeypatch):
+    in_file = lgnd_test_data.get_path("fcio/L200-comm-20211130-phy-spms.fcio")
+
+    # buffer_size=5 makes open_stream() raise *after* the file is opened, so a
+    # resource is leaked unless the context manager closes it on the way out
+    closed = []
+    orig_close = FCStreamer.close_stream
+    monkeypatch.setattr(
+        FCStreamer,
+        "close_stream",
+        lambda self: (closed.append(True), orig_close(self)),
+    )
+
+    with pytest.raises(ValueError):
+        with open_stream(in_file, buffer_size=5):
+            pass
+    assert closed == [True]  # cleanup attempted despite the failed open

--- a/tests/test_data_streamer.py
+++ b/tests/test_data_streamer.py
@@ -1,0 +1,47 @@
+import lh5
+
+from daq2lh5 import build_raw
+from daq2lh5.fc.fc_streamer import FCStreamer
+from daq2lh5.raw_buffer import RawBuffer
+
+
+def test_iteration_matches_build_raw(lgnd_test_data, tmptestdir):
+    in_file = lgnd_test_data.get_path("fcio/L200-comm-20211130-phy-spms.fcio")
+
+    rows = {}
+    n_chunks = 0
+    streamer = FCStreamer()
+    streamer.open_stream(in_file, buffer_size=6)
+    for chunk_list in streamer:
+        n_chunks += 1
+        assert isinstance(chunk_list, list)
+        for rb in chunk_list:
+            assert isinstance(rb, RawBuffer)
+            assert rb.loc > 0
+            rows[rb.out_name] = rows.get(rb.out_name, 0) + rb.loc
+    streamer.close_stream()
+
+    assert n_chunks > 1  # buffer_size=6 forces multiple chunks
+    assert rows  # we decoded something
+
+    # the disk-writing path must agree on the number of decoded rows
+    out_file = f"{tmptestdir}/test_data_streamer_iter.lh5"
+    build_raw(in_file, out_spec=out_file, buffer_size=6, overwrite=True)
+    for out_name, n_rows in rows.items():
+        assert n_rows == lh5.read_n_rows(out_name, out_file)
+
+
+def test_iteration_clears_buffers_and_terminates(lgnd_test_data):
+    in_file = lgnd_test_data.get_path("fcio/L200-comm-20211130-phy-spms.fcio")
+
+    streamer = FCStreamer()
+    streamer.open_stream(in_file, buffer_size=1024)
+    chunks = list(streamer)
+    assert len(chunks) > 0
+    # buffers were cleared after the final yield
+    for rb_list in streamer.rb_lib.values():
+        for rb in rb_list:
+            assert rb.loc == 0
+    # stream is exhausted: a fresh iteration yields nothing
+    assert list(streamer) == []
+    streamer.close_stream()


### PR DESCRIPTION
## Motivation

This PR factors out the streamer layer in `build_raw()` and exposes it as a small public API for decoding DAQ data in memory. As the API yields LGDO tables, which can be viewed as Awkward arrays, Arrow tables, etc., we could build online monitoring, or convert DAQ files to other storage formats.

## Changes

Purely additive; `build_raw()` behavior is unchanged.

- **`get_streamer(in_stream, ...)`**: stream-type auto-detection and streamer selection, extracted verbatim from `build_raw()` and made public.
- **`DataStreamer.__iter__`**: implements the `for chunk in ds:` interface the class docstring already advertises. Wraps `read_chunk()` and clears consumed buffers after each yield, so the clearing contract documented on `read_chunk()` is enforced structurally instead of left to the caller.
- **`open_stream(in_stream, ...)`** (module-level): context manager composing the two, following the same convenience pattern as `lh5.read()` vs `LH5Store.read()`. Takes the stream path once, yields `(streamer, header_data)`, and guarantees `close_stream()` on exit, including on exceptions.

```python
from daq2lh5 import open_stream

with open_stream("daq.fcio") as (streamer, header_data):
    for chunk_list in streamer:
        for rb in chunk_list:
            # rb.lgdo is an LGDO Table; rows [0:rb.loc] are fresh
            do_something(rb.out_name, rb.lgdo, rb.loc)
```

## Example: an alternative sink

As LGDO tables can be viewed as Arrow tables now, any data format that supports writing from Arrow can be serialized. Here, I show how Parquet can be an alternative sink:

```python
import pyarrow.parquet as pq
from daq2lh5 import open_stream
from daq2lh5.buffer_processor.buffer_processor import buffer_processor
from daq2lh5.raw_buffer import RawBufferLibrary

spec = {
    "FCEventDecoder": {
        "geds": {  # windowed waveforms
            "key_list": [[24, 64]],
            "out_stream": "",
            "proc_spec": {"window": ["waveform", 1000, 2000, "windowed_waveform"]},
        },
        "spms": {  # raw waveforms
            "key_list": [[6, 23]],
            "out_stream": "",
        },
    }
}

writers = {}
with open_stream("daq.fcio", rb_lib=RawBufferLibrary(config=spec),
                 chunk_mode="only_full") as (streamer, header_data):
    for chunk_list in streamer:
        for rb in chunk_list:
            lgdo = buffer_processor(rb) if rb.proc_spec is not None else rb.lgdo
            t = lgdo.view_as("arrow").slice(0, rb.loc)
            if rb.out_name not in writers:
                writers[rb.out_name] = pq.ParquetWriter(f"{rb.out_name}.parquet", t.schema)
            writers[rb.out_name].write_table(t)
for w in writers.values():
    w.close()
```

- `chunk_mode="only_full"` makes each group's buffer flush only when full, so every write is ~`buffer_size` rows per group even when groups fill at different rates.

## Memory

Decoded data only ever occupies the fixed-size `RawBuffer`s, exactly as in `build_raw()`; the memory profile is set by what the consumer does with each chunk. Buffers are reused, so consumers that retain chunks must copy or serialize them before advancing (documented on `__iter__`).

## Possible follow-up

`build_raw()` could be refactored on top of `open_stream()` + `__iter__`. Besides simplifying it, this would fix a stream leak: its manual `close_stream()` call is skipped when an error is raised after opening (e.g. the `FileExistsError` overwrite check). Left out here to keep the PR additive.
